### PR TITLE
Logger plugin improvement

### DIFF
--- a/Shared-Addons/recursio-loggerplugin/Logger.gd
+++ b/Shared-Addons/recursio-loggerplugin/Logger.gd
@@ -11,19 +11,6 @@ extends Node  # Needed to work as a singleton
 ##================##
 
 
-var _time_between_config_reloads = 3.0
-var _time_to_next_config_reload
-
-func _ready():
-	load_config()
-	_time_to_next_config_reload = _time_between_config_reloads
-
-func _process(delta):
-	_time_to_next_config_reload-=delta
-	if _time_to_next_config_reload<=0:
-		load_config()
-		_time_to_next_config_reload = _time_between_config_reloads
-
 class ExternalSink:
 	# Queue modes
 	enum QUEUE_MODES {
@@ -325,19 +312,18 @@ const ERROR_MESSAGES = {
 ##=============##
 
 # Configuration
-var default_all_config = [1, 1, 1, 1, 1]
 var default_output_level = INFO
 # TODO: Find (or implement in Godot) a more clever way to achieve that
 
 var default_output_strategies = [STRATEGY_PRINT, STRATEGY_PRINT, STRATEGY_PRINT, STRATEGY_PRINT, STRATEGY_PRINT]
 var default_logfile_path = "user://%s.log" % ProjectSettings.get_setting("application/config/name")  # TODO @File
-var default_configfile_path = "res://addons/recursio-loggerplugin/%s.cfg" % PLUGIN_NAME
+var default_configfile_path = "user://%s.cfg" % PLUGIN_NAME
 
 # e.g. "[INFO] [main] The young alpaca started growing a goatie."
 var output_format = "[{TIME}] [{LVL}] [{MOD}]{ERR_MSG} {MSG}"
 # Example with all supported placeholders: "YYYY.MM.DD hh.mm.ss"
 # would output e.g.: "2020.10.09 12:10:47".
-var time_format = "hh:mm:ss.ms"
+var time_format = "hh:mm:ss"
 
 # Holds the name of the debug module for easy usage across all logging functions.
 var default_module_name = "main"
@@ -427,24 +413,13 @@ func add_module(name, output_level = default_output_level, output_strategies = d
 		if logfile == null:
 			logfile = get_external_sink(default_logfile_path)
 		modules[name] = Module.new(name, output_level, output_strategies, logfile)
-	var loggerconfig = ConfigFile.new()
-	
-	var err = loggerconfig.load("res://addons/recursio-loggerplugin/loggerconfig.ini")
-	if err != OK:
-		print("ERROR: Could not load config file!")
-	
-	for level in LEVELS:
-		if not loggerconfig.has_section_key(name, level):
-			loggerconfig.set_value(name, level, true)
-	loggerconfig.save("res://addons/recursio-loggerplugin/loggerconfig.ini")
-	
 	return modules[name]
 
 
 func get_module(module = default_module_name):
 	"""Retrieve the given module if it exists; if not, it will be created."""
 	if not modules.has(module):
-		print("The requested module '%s' does not exist. It will be created with default values." % module)
+		info("The requested module '%s' does not exist. It will be created with default values." % module, PLUGIN_NAME)
 		add_module(module)
 	return modules[module]
 
@@ -571,16 +546,13 @@ func get_default_output_level():
 # * ss = Seconds
 func get_formatted_datetime():
 	var datetime = OS.get_datetime()
-	var ms = OS.get_system_time_msecs() % 1000
-	#var ms = OS.get_ticks_msec() % 1000
 	var result = time_format
-	result = result.replacen("YYYY", "%04d" % [datetime.year])
-	result = result.replacen("MM", "%02d" % [datetime.month])
-	result = result.replacen("DD", "%02d" % [datetime.day])
-	result = result.replacen("hh", "%02d" % [datetime.hour])
-	result = result.replacen("mm", "%02d" % [datetime.minute])
-	result = result.replacen("ss", "%02d" % [datetime.second])
-	result = result.replacen("ms", "%03d" % [ms])
+	result = result.replace("YYYY", "%04d" % [datetime.year])
+	result = result.replace("MM", "%02d" % [datetime.month])
+	result = result.replace("DD", "%02d" % [datetime.day])
+	result = result.replace("hh", "%02d" % [datetime.hour])
+	result = result.replace("mm", "%02d" % [datetime.minute])
+	result = result.replace("ss", "%02d" % [datetime.second])
 	return result
 
 
@@ -693,7 +665,6 @@ func clear_memory():
 # ----------------------------
 
 const config_fields := {
-	default_all_config = "default_all_config",
 	default_output_level = "default_output_level",
 	default_output_strategies = "default_output_strategies",
 	default_logfile_path = "default_logfile_path",
@@ -712,7 +683,6 @@ func save_config(configfile = default_configfile_path):
 	var config = ConfigFile.new()
 
 	# Store default config
-	config.set_value(PLUGIN_NAME, config_fields.default_all_config, default_all_config)
 	config.set_value(PLUGIN_NAME, config_fields.default_output_level, default_output_level)
 	config.set_value(PLUGIN_NAME, config_fields.default_output_strategies, default_output_strategies)
 	config.set_value(PLUGIN_NAME, config_fields.default_logfile_path, default_logfile_path)
@@ -751,18 +721,17 @@ func load_config(configfile = default_configfile_path):
 	# Look for the file
 	var dir = Directory.new()
 	if not dir.file_exists(configfile):
-		print("Could not load the config in '%s', the file does not exist." % configfile)
+		warn("Could not load the config in '%s', the file does not exist." % configfile, PLUGIN_NAME)
 		return ERR_FILE_NOT_FOUND
 
 	# Load its contents
 	var config = ConfigFile.new()
 	var err = config.load(configfile)
 	if err:
-		print("Could not load the config in '%s'; exited with error %d." % [configfile, err])
+		warn("Could not load the config in '%s'; exited with error %d." % [configfile, err], PLUGIN_NAME)
 		return err
 
 	# Load default config
-	default_all_config = config.get_value(PLUGIN_NAME, config_fields.default_all_config, default_all_config)
 	default_output_level = config.get_value(PLUGIN_NAME, config_fields.default_output_level, default_output_level)
 	default_output_strategies = config.get_value(PLUGIN_NAME, config_fields.default_output_strategies, default_output_strategies)
 	default_logfile_path = config.get_value(PLUGIN_NAME, config_fields.default_logfile_path, default_logfile_path)
@@ -781,6 +750,8 @@ func load_config(configfile = default_configfile_path):
 			module_cfg["name"], module_cfg["output_level"], module_cfg["output_strategies"], get_external_sink(module_cfg["external_sink"]["path"])
 		)
 		modules[module_cfg["name"]] = module
+
+	info("Successfully loaded the config from '%s'." % configfile, PLUGIN_NAME)
 	return OK
 
 

--- a/Shared-Addons/recursio-loggerplugin/Logger.gd
+++ b/Shared-Addons/recursio-loggerplugin/Logger.gd
@@ -402,7 +402,7 @@ func error(message, module = default_module_name, error_code = -1):
 # Module management
 # -----------------
 
-
+signal module_added
 func add_module(name, output_level = default_output_level, output_strategies = default_output_strategies, logfile = null):
 	"""Add a new module with the given parameter or (by default) the
 	default ones.
@@ -413,6 +413,7 @@ func add_module(name, output_level = default_output_level, output_strategies = d
 		if logfile == null:
 			logfile = get_external_sink(default_logfile_path)
 		modules[name] = Module.new(name, output_level, output_strategies, logfile)
+		emit_signal("module_added")
 	return modules[name]
 
 

--- a/Shared-Addons/recursio-loggerplugin/LoggerPlugin.gd
+++ b/Shared-Addons/recursio-loggerplugin/LoggerPlugin.gd
@@ -1,17 +1,15 @@
 tool
 extends EditorPlugin
 
-
 const logger_plugin_scene = preload("res://addons/recursio-loggerplugin/LoggerPlugin.tscn")
 const module_config_scene = preload("res://addons/recursio-loggerplugin/Module.tscn")
 const module_mode_toggle_scene = preload("res://addons/recursio-loggerplugin/ModuleModeToggle.tscn")
-
 
 var logger_plugin_instance
 
 var config
 
-var modes = ["VERBOSE","DEBUG", "INFO", "WARN", "ERROR"]
+var modes := ["VERBOSE","DEBUG", "INFO", "WARN", "ERROR"]
 
 func _enter_tree():
 	logger_plugin_instance = logger_plugin_scene.instance()
@@ -19,104 +17,120 @@ func _enter_tree():
 	get_editor_interface().get_editor_viewport().add_child(logger_plugin_instance)
 	# Hide the main panel. Very much required.
 	make_visible(false)
+	logger_plugin_instance.get_node("TitelBar/Refresh").connect("pressed",self,"_refresh")
+	logger_plugin_instance.get_node("TitelBar/Editable").connect("toggled",self,"_toggle_editable")
 
-var time_between_config_reads = 5.0
-var time_to_next_config_read
-
+func build():
+	logger_plugin_instance.get_node("TitelBar/Editable").pressed = false
+	return true
+	
 func _ready():
-	_read_config_file()
-	time_to_next_config_read = time_between_config_reads
-
-func _process(delta):
-	time_to_next_config_read -= delta
-	if time_to_next_config_read <= 0:
-		time_to_next_config_read = time_between_config_reads
-		for module in logger_plugin_instance.get_node("ModulesBackground/ModulesScrollContainer/Modules").get_children():
-			module.queue_free()
-		_read_config_file()
-
-func _read_config_file():
-	config = ConfigFile.new()
-	var err = config.load("res://addons/recursio-loggerplugin/loggerconfig.ini")
-	if err != OK:
-		print("ERROR: Could not load config file!")
-		return
-
 	_add_modes()
-	for module in config.get_sections():
-		_add_new_module(module)
-	#_save_settings()
-
-
+	_refresh()
+	_is_editable()
+	
 func _add_modes():
-	var module_instance = module_config_scene.instance()
-	module_instance.get_node("ModuleName").text = "Modes:"
-	for mode in modes:
-		var label: Label = Label.new()
-		label.text = mode
-		module_instance.add_child(label)
-
+	var mode_instance = module_config_scene.instance()
+	mode_instance.get_node("ModuleName").text = "Modes:"
+	for i in range(modes.size()):
 		var toggle = module_mode_toggle_scene.instance()
-		toggle.connect("toggled",self,"_on_module_all_toggled", [mode])
+		toggle.text = modes[i]
+		toggle.connect("toggled",self,"_on_mode_toggled", [i])
+		mode_instance.add_child(toggle)
+	logger_plugin_instance.get_node("ModesBackground/ModesScrollContainer/Modes").add_child(mode_instance)
+
+func _refresh():
+	_refresh_config()
+	_refresh_modules()
+	_refresh_modes()
+	_is_editable()
+	
+func _refresh_modules():
+	_clear_modules()
+	_load_modules()
+
+func _refresh_config():
+	config = ConfigFile.new()
+	var err = config.load(LoggerPluginSingleton.CONFIG_PATH)
+	if err:
+		print("Could not load the config in '%s'; exited with error %d." % [LoggerPluginSingleton.CONFIG_PATH, err])
+		return err
+
+func _clear_modules():
+	for module in logger_plugin_instance.get_node("ModulesBackground/ModulesScrollContainer/Modules").get_children():
+		module.queue_free()
+
+func _load_modules():
+	if not config.has_section(Logger.PLUGIN_NAME):
+		return
+	var modules = config.get_value(Logger.PLUGIN_NAME, Logger.config_fields.modules)
+	for i in range(modules.size()):
+		if modules[i].has("name"):
+			_add_new_module(modules[i].name, i, modules[i].output_strategies)
+
+func _add_new_module(module_name, module_index, output_strategies):
+	var module_instance = module_config_scene.instance()
+	module_instance.get_node("ModuleName").text = module_name
+	for i in range(output_strategies.size()):
+		var toggle = module_mode_toggle_scene.instance()
+		toggle.pressed = output_strategies[i]
+		toggle.text = modes[i]
+		toggle.connect("toggled",self,"_on_module_button_toggled", [toggle, module_index, i])
 		module_instance.add_child(toggle)
 	logger_plugin_instance.get_node("ModulesBackground/ModulesScrollContainer/Modules").add_child(module_instance)
 
+func _refresh_modes():
+	if not config.has_section(Logger.PLUGIN_NAME):
+		return
+	var modes_status =[false,false,false,false,false]
+	var modules = config.get_value(Logger.PLUGIN_NAME, Logger.config_fields.modules)
+	for module in modules:
+		if module.has("name"):
+			for i in range(module.output_strategies.size()):
+				if module.output_strategies[i]:
+					modes_status[i]=true
+	var i = 0
+	for mode in logger_plugin_instance.get_node("ModesBackground/ModesScrollContainer/Modes").get_children()[0].get_children():
+		if mode is CheckButton:
+			mode.disconnect("toggled",self,"_on_mode_toggled")
+			mode.pressed = modes_status[i]
+			mode.connect("toggled",self,"_on_mode_toggled", [i])
+			i+=1
 
-func _add_new_module(module):
-	var module_instance = module_config_scene.instance()
-	module_instance.get_node("ModuleName").text = module
-	for mode in modes:
-		var toggle = module_mode_toggle_scene.instance()
-		if config.has_section_key(module, mode):
-			toggle.pressed = config.get_value(module, mode)
-		else:
-			toggle.pressed = true
-			config.set_value(module, mode, true)
-		toggle.connect("toggled",self,"_on_module_button_toggled", [module,mode])
-		module_instance.add_child(toggle)
-	logger_plugin_instance.get_node("ModulesBackground/ModulesScrollContainer/Modules").add_child(module_instance)
+func _on_module_button_toggled(active: bool, button: CheckButton, module_index: int, mode_index:int):
+	if _is_editable():
+		var modules = config.get_value(Logger.PLUGIN_NAME, Logger.config_fields.modules)
+		modules[module_index].output_strategies[mode_index] = int(active)
+		config.save(LoggerPluginSingleton.CONFIG_PATH)
+	_refresh()
 
-func _save_settings():
-	config.save("res://addons/recursio-loggerplugin/loggerconfig.ini")
-	_save_config_file()
+func _is_editable() ->bool:
+	_refresh_config()
+	var editable = false
+	if config.has_section_key(LoggerPluginSingleton.PLUGIN_NAME, LoggerPluginSingleton.GAME_RUNNNIG):
+		if not config.get_value(LoggerPluginSingleton.PLUGIN_NAME, LoggerPluginSingleton.GAME_RUNNNIG):
+			editable = true
+	logger_plugin_instance.get_node("TitelBar/Editable").disconnect("toggled", self, "_toggle_editable")
+	logger_plugin_instance.get_node("TitelBar/Editable").pressed = editable
+	logger_plugin_instance.get_node("TitelBar/Editable").connect("toggled", self, "_toggle_editable")
+	return editable
 
+func _toggle_editable(active):
+	_refresh_config()
+	config.set_value(LoggerPluginSingleton.PLUGIN_NAME, LoggerPluginSingleton.GAME_RUNNNIG, not active)
+	config.save(LoggerPluginSingleton.CONFIG_PATH)
 
-#TODO: this is hacky af
-func _save_config_file():
-	var logger_config = ConfigFile.new()
-	var section = "logger"
-	logger_config.set_value(section, "default_all_config",[ 1, 1, 1, 1, 1 ])
-	logger_config.set_value(section, "default_output_level",0)
-	logger_config.set_value(section, "default_output_strategies",[ 1, 1, 1, 1, 1 ])
-	logger_config.set_value(section, "default_logfile_path", "user://%s.log" % ProjectSettings.get_setting("application/config/name"))
-	logger_config.set_value(section, "max_memory_size", 30)
-	var external_sink = {
-		"path": "user://%s.log" % ProjectSettings.get_setting("application/config/name"),
-		"queue_mode": 0
-	}
-	logger_config.set_value(section, "external_sinks", [external_sink])
-	var modules = []
-	for module in config.get_sections():
-		var module_entry = {}
-		module_entry["external_sink"]=external_sink
-		module_entry["name"] = module
-		module_entry["output_level"]=1
-		var output_strategies = []
-		for mode in modes:
-			output_strategies.append(config.get_value(module,mode) as int)
-		module_entry["output_strategies"] = output_strategies
-		modules.append(module_entry)
-	logger_config.set_value(section, "modules", modules)
-	logger_config.save("res://addons/recursio-loggerplugin/logger.cfg")
-
-func _on_module_button_toggled(active: bool, module:String, mode:String):
-	config.set_value(module, mode, active)
-	_save_settings()
-
-func _on_module_all_toggled(active: bool, mode:String):
-	for module in config.get_sections():
-		config.set_value(module, mode, active)
-	_save_settings()
+func _on_mode_toggled(active: bool, mode_index:int):
+	if not config.has_section(Logger.PLUGIN_NAME):
+		return
+	if _is_editable():
+		var modules = config.get_value(Logger.PLUGIN_NAME, Logger.config_fields.modules)
+		for module in modules:
+			if module.has("name"):
+				module.output_strategies[mode_index] = int(active)
+		config.save(LoggerPluginSingleton.CONFIG_PATH)
+	_refresh()
+	pass
 
 func _exit_tree():
 	if logger_plugin_instance:
@@ -130,7 +144,7 @@ func make_visible(visible):
 		logger_plugin_instance.visible = visible
 
 func get_plugin_name():
-	return "Logger Config"
+	return "LoggerConfig"
 
 func get_plugin_icon():
 	return get_editor_interface().get_base_control().get_icon("Node", "EditorIcons")

--- a/Shared-Addons/recursio-loggerplugin/LoggerPlugin.tscn
+++ b/Shared-Addons/recursio-loggerplugin/LoggerPlugin.tscn
@@ -1,4 +1,7 @@
-[gd_scene format=2]
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://addons/recursio-loggerplugin/ModuleModeToggle.tscn" type="PackedScene" id=1]
+[ext_resource path="res://addons/recursio-loggerplugin/Module.tscn" type="PackedScene" id=2]
 
 [node name="LoggerPlugin" type="VBoxContainer"]
 anchor_right = 1.0
@@ -13,20 +16,64 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Title" type="Label" parent="."]
+[node name="TitelBar" type="HBoxContainer" parent="."]
 margin_right = 984.0
 margin_bottom = 100.0
-rect_min_size = Vector2( 100, 100 )
+
+[node name="Title" type="Label" parent="TitelBar"]
+margin_right = 700.0
+margin_bottom = 100.0
+rect_min_size = Vector2( 700, 100 )
 text = "Logger Config"
 align = 1
 valign = 1
 
-[node name="ModulesBackground" type="Panel" parent="."]
+[node name="Editable" type="CheckButton" parent="TitelBar"]
+margin_left = 704.0
+margin_right = 835.0
+margin_bottom = 100.0
+text = "Editable"
+
+[node name="Refresh" type="Button" parent="TitelBar"]
+margin_left = 839.0
+margin_right = 984.0
+margin_bottom = 100.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+text = "Refresh"
+
+[node name="ModesBackground" type="Panel" parent="."]
 margin_top = 104.0
+margin_right = 984.0
+margin_bottom = 149.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="ModesScrollContainer" type="ScrollContainer" parent="ModesBackground"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 20.0
+margin_right = -20.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Modes" type="VBoxContainer" parent="ModesBackground/ModesScrollContainer"]
+margin_right = 944.0
+size_flags_horizontal = 3
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="ModulesBackground" type="Panel" parent="."]
+margin_top = 153.0
 margin_right = 984.0
 margin_bottom = 560.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
+size_flags_stretch_ratio = 9.0
 
 [node name="ModulesScrollContainer" type="ScrollContainer" parent="ModulesBackground"]
 anchor_right = 1.0
@@ -43,7 +90,13 @@ __meta__ = {
 
 [node name="Modules" type="VBoxContainer" parent="ModulesBackground/ModulesScrollContainer"]
 margin_right = 944.0
+margin_bottom = 50.0
 size_flags_horizontal = 3
 __meta__ = {
 "_edit_use_anchors_": false
 }
+
+[node name="Module" parent="ModulesBackground/ModulesScrollContainer/Modules" instance=ExtResource( 2 )]
+margin_right = 944.0
+
+[node name="DebugActive" parent="ModulesBackground/ModulesScrollContainer/Modules/Module" instance=ExtResource( 1 )]

--- a/Shared-Addons/recursio-loggerplugin/LoggerPluginSingleton.gd
+++ b/Shared-Addons/recursio-loggerplugin/LoggerPluginSingleton.gd
@@ -1,0 +1,32 @@
+extends Node
+
+const PLUGIN_NAME = "loggerplugin"
+const GAME_RUNNNIG = "game_running"
+const CONFIG_PATH = "res://addons/recursio-loggerplugin/logger.cfg"
+
+func _ready():
+	var config = _get_config()
+	_toggle_game_running(config, true)
+	Logger.default_configfile_path = CONFIG_PATH
+	if config.has_section(Logger.PLUGIN_NAME):
+		Logger.load_config()
+	Logger.connect("module_added",self,"_on_module_added")
+
+func _on_module_added():
+	Logger.save_config()
+
+func _notification(what):
+	if what == MainLoop.NOTIFICATION_WM_QUIT_REQUEST:
+		Logger.save_config()
+		var config = _get_config()
+		_toggle_game_running(config, false)
+		get_tree().quit() # default behavior
+
+func _get_config():
+	var config = ConfigFile.new()
+	var err = config.load(CONFIG_PATH)
+	return config
+
+func _toggle_game_running(config, value):
+	config.set_value(PLUGIN_NAME, GAME_RUNNNIG, value)
+	config.save(CONFIG_PATH)

--- a/Shared-Addons/recursio-loggerplugin/Module.tscn
+++ b/Shared-Addons/recursio-loggerplugin/Module.tscn
@@ -12,5 +12,6 @@ __meta__ = {
 margin_right = 200.0
 margin_bottom = 50.0
 rect_min_size = Vector2( 200, 50 )
-text = "Network Validation"
+text = "Modes"
 valign = 1
+clip_text = true

--- a/Shared-Addons/recursio-loggerplugin/ModuleModeToggle.tscn
+++ b/Shared-Addons/recursio-loggerplugin/ModuleModeToggle.tscn
@@ -1,7 +1,14 @@
-[gd_scene format=2]
+[gd_scene load_steps=2 format=2]
+
+[sub_resource type="StyleBoxFlat" id=1]
+bg_color = Color( 0.972549, 0, 0, 1 )
 
 [node name="DebugActive" type="CheckButton"]
 margin_left = 204.0
 margin_right = 280.0
 margin_bottom = 50.0
 rect_min_size = Vector2( 50, 30 )
+custom_styles/disabled = SubResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/recursio-client/Global/Server.gd
+++ b/recursio-client/Global/Server.gd
@@ -48,6 +48,10 @@ func connect_to_server():
 	get_tree().connect("connection_failed", self, "_on_connection_failed")
 	get_tree().connect("connected_to_server", self, "_on_connection_succeeded")
 
+func _notification(what):
+	if what == MainLoop.NOTIFICATION_WM_QUIT_REQUEST:
+		network.close_connection()
+		get_tree().quit() # default behavior
 
 func _on_connection_failed():
 	Logger.info("Failed to connect to server", "connection")

--- a/recursio-client/project.godot
+++ b/recursio-client/project.godot
@@ -117,10 +117,11 @@ config/icon="res://icon.png"
 
 [autoload]
 
+Logger="*res://addons/recursio-loggerplugin/Logger.gd"
+LoggerPluginSingleton="*res://addons/recursio-loggerplugin/LoggerPluginSingleton.gd"
 Constants="*res://Shared/Constants.gd"
 Server="*res://Global/Server.gd"
 GlobalActionManager="*res://Shared/Actions/ActionManager.gd"
-Logger="*res://addons/recursio-loggerplugin/Logger.gd"
 InputManager="*res://Global/InputManager.gd"
 
 [debug]

--- a/recursio-server/project.godot
+++ b/recursio-server/project.godot
@@ -130,6 +130,7 @@ config/icon="res://icon.png"
 [autoload]
 
 Logger="*res://addons/recursio-loggerplugin/Logger.gd"
+LoggerPluginSingleton="*res://addons/recursio-loggerplugin/LoggerPluginSingleton.gd"
 Constants="*res://Shared/Constants.gd"
 
 [editor_plugins]


### PR DESCRIPTION
Rewrote basically everything.

UI is now only usable outside of play mode. But because there is no way (that I could find) to actually react to the end of play mode, a manual check button to reenable editability was added.
If play mode is exited via ``X`` button or ``alt`` + ``f4`` editability gets toggled correctly. 

UI also does not refresh persistently anymore, thus a refresh button was added. 
It does also refresh automatically when toggling any check button, on opening of the project and during the build step when playing, as those were the only useful events I could access without querying randomly every few seconds as it was done before the rewrite. This improved performance and eliminated some messy edge cases that happened while both projects were concurrently writing to the config files.

All in all some usability was sacrificed for the sake of stability and consistent behaviour. 