### PR TITLE
#105 move capture points state in 3D world

### DIFF
--- a/recursio-client/Level/CapturePoint.tscn
+++ b/recursio-client/Level/CapturePoint.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://Level/CapturePoint.gd" type="Script" id=1]
+[ext_resource path="res://Resources/Icons/circle_white_256x256.png" type="Texture" id=2]
 
 [sub_resource type="CylinderShape" id=1]
 
@@ -10,6 +11,9 @@ albedo_color = Color( 0, 1, 0.811765, 1 )
 
 [sub_resource type="CylinderMesh" id=3]
 height = 0.4
+
+[sub_resource type="ViewportTexture" id=4]
+viewport_path = NodePath("Sprite3D/Viewport")
 
 [node name="CapturePoint" type="Spatial"]
 script = ExtResource( 1 )
@@ -21,8 +25,30 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0 )
 shape = SubResource( 1 )
 
 [node name="MeshInstance" type="MeshInstance" parent="."]
-layers = 36
+transform = Transform( 1, 0, 0, 0, 0.2, 0, 0, 0, 1, 0, 0, 0 )
+visible = false
+layers = 548
 material_override = SubResource( 2 )
 cast_shadow = 0
 mesh = SubResource( 3 )
 material/0 = null
+
+[node name="Sprite3D" type="Sprite3D" parent="."]
+layers = 512
+axis = 1
+billboard = 2
+texture = SubResource( 4 )
+
+[node name="Viewport" type="Viewport" parent="Sprite3D"]
+size = Vector2( 260, 260 )
+transparent_bg = true
+usage = 0
+render_target_v_flip = true
+
+[node name="TextureProgress" type="TextureProgress" parent="Sprite3D/Viewport"]
+margin_right = 40.0
+margin_bottom = 40.0
+max_value = 1.0
+step = 0.05
+texture_progress = ExtResource( 2 )
+fill_mode = 4

--- a/recursio-client/Level/CapturePoint.tscn
+++ b/recursio-client/Level/CapturePoint.tscn
@@ -26,7 +26,6 @@ shape = SubResource( 1 )
 
 [node name="MeshInstance" type="MeshInstance" parent="."]
 transform = Transform( 1, 0, 0, 0, 0.2, 0, 0, 0, 1, 0, 0, 0 )
-visible = false
 layers = 548
 material_override = SubResource( 2 )
 cast_shadow = 0


### PR DESCRIPTION
basic implementation works, but there seems to be a problem when using ascii shader for capture points meshInstance: progress circle overlaps 3D Model.

Also three errors are thrown for each capture point:
![image](https://user-images.githubusercontent.com/24638443/142593749-7b8789de-1b7b-43fe-bd0b-6897c9b7bc11.png)
although this seems to dont cause actual crashes.
Maybe this can be prevented by setting the ViewportTexture for the Sprite3D after adding the capture point to the scene, but I dont know how xD