### PR TITLE
User Settings

### DIFF
--- a/Shared/Actions/ActionManager.gd
+++ b/Shared/Actions/ActionManager.gd
@@ -119,6 +119,7 @@ func set_active(action: Action, character: CharacterBase, tree_position: Spatial
 	if action.sound and plays_sounds:
 		var audio_player = AudioStreamPlayer3D.new()
 		audio_player.stream = action.sound
+		audio_player.bus = "Effects"
 		get_tree().get_root().add_child(audio_player)
 		audio_player.global_transform = tree_position.global_transform
 		audio_player.unit_size = 20

--- a/recursio-client/Characters/CharacterAudioPlayer.tscn
+++ b/recursio-client/Characters/CharacterAudioPlayer.tscn
@@ -12,13 +12,17 @@ script = ExtResource( 1 )
 stream = ExtResource( 2 )
 unit_size = 0.1
 autoplay = true
+bus = "Effects"
 
 [node name="CaptureAudio" type="AudioStreamPlayer3D" parent="."]
+bus = "Effects"
 
 [node name="SpawnAudio" type="AudioStreamPlayer3D" parent="."]
 stream = ExtResource( 4 )
 unit_size = 10.0
+bus = "Effects"
 
 [node name="DieAudio" type="AudioStreamPlayer3D" parent="."]
 stream = ExtResource( 3 )
 unit_size = 10.0
+bus = "Effects"

--- a/recursio-client/Characters/Player.tscn
+++ b/recursio-client/Characters/Player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=26 format=2]
+[gd_scene load_steps=27 format=2]
 
 [ext_resource path="res://Shared/Characters/PlayerBase.tscn" type="PackedScene" id=1]
 [ext_resource path="res://Characters/Player.gd" type="Script" id=2]
@@ -19,6 +19,7 @@
 [ext_resource path="res://Characters/Visuals/Selector.gd" type="Script" id=17]
 [ext_resource path="res://Characters/Visuals/Selector.obj" type="ArrayMesh" id=18]
 [ext_resource path="res://Characters/CharacterAudioPlayer.tscn" type="PackedScene" id=19]
+[ext_resource path="res://Characters/SettingAsciiRenderer.gd" type="Script" id=20]
 
 [sub_resource type="SpatialMaterial" id=1]
 albedo_color = Color( 1, 0, 0.866667, 1 )
@@ -148,6 +149,7 @@ __meta__ = {
 }
 
 [node name="AsciiRenderer" parent="KinematicBody/AsciiViewportContainer/Viewport/LerpedFollow/Camera" index="0" instance=ExtResource( 14 )]
+script = ExtResource( 20 )
 
 [node name="RemoteTransform" type="RemoteTransform" parent="KinematicBody/AsciiViewportContainer/Viewport/LerpedFollow/Camera" index="1"]
 remote_path = NodePath("../../../../../NormalViewportContainer/Viewport/Camera")

--- a/recursio-client/Characters/SettingAsciiRenderer.gd
+++ b/recursio-client/Characters/SettingAsciiRenderer.gd
@@ -1,0 +1,6 @@
+extends MeshInstance
+
+
+func _ready():
+	var x_size = UserSettings.get_setting("video", "ascii_size")
+	get_surface_material(0).set_shader_param("character_size", Vector2(x_size, x_size * 2))

--- a/recursio-client/Global/UserSettings.gd
+++ b/recursio-client/Global/UserSettings.gd
@@ -1,0 +1,29 @@
+extends Node
+
+signal setting_changed(setting_header, setting_name)
+
+export var always_apply_defaults_at_startup := true
+
+var settings_config = ConfigFile.new()
+
+const SETTINGS_PATH = "user://settings.ini"
+
+
+func _ready():
+	# Load previous settings
+	var err = settings_config.load(SETTINGS_PATH)
+
+	# If the file didn't load (first ever game start), save the defaults there initially
+	if err != OK or always_apply_defaults_at_startup:
+		settings_config.load("res://default-settings.ini") # this should never fail
+		settings_config.save(SETTINGS_PATH)
+
+
+func get_setting(setting_header, setting_name, default = null):
+	return settings_config.get_value(setting_header, setting_name, default)
+
+
+func set_setting(setting_header, setting_name, value):
+	settings_config.set_value(setting_header, setting_name, value)
+	settings_config.save(SETTINGS_PATH)
+	emit_signal("setting_changed", setting_header, setting_name, value)

--- a/recursio-client/Level/CapturePoint.tscn
+++ b/recursio-client/Level/CapturePoint.tscn
@@ -53,3 +53,4 @@ fill_mode = 5
 stream = ExtResource( 3 )
 unit_size = 0.1
 autoplay = true
+bus = "Effects"

--- a/recursio-client/Rendering/OverviewLight.gd
+++ b/recursio-client/Rendering/OverviewLight.gd
@@ -19,6 +19,7 @@ func _physics_process(delta):
 		if omni_range > 10.0 and not _audio_played_this_pulse:
 			var audio_player = AudioStreamPlayer.new()
 			audio_player.stream = preload("res://Resources/Audio/Effects/Pulse.ogg")
+			audio_player.bus = "Effects"
 			add_child(audio_player)
 			audio_player.connect("finished", audio_player, "queue_free")
 			audio_player.play()

--- a/recursio-client/UI/Menus/AsciiBackground.gd
+++ b/recursio-client/UI/Menus/AsciiBackground.gd
@@ -1,0 +1,15 @@
+extends ColorRect
+
+
+func _ready():
+	update_ascii_size(UserSettings.get_setting("video", "ascii_size"))
+	UserSettings.connect("setting_changed", self, "_on_setting_changed")
+
+
+func _on_setting_changed(setting_header, setting_name, value):
+	if setting_header == "video" and setting_name == "ascii_size":
+		update_ascii_size(value)
+
+
+func update_ascii_size(new_x_size):
+	material.set_shader_param("character_size", Vector2(new_x_size, new_x_size * 2))

--- a/recursio-client/UI/Menus/AsciiSlider.gd
+++ b/recursio-client/UI/Menus/AsciiSlider.gd
@@ -1,0 +1,10 @@
+extends HSlider
+
+
+func _ready() -> void:
+	connect("value_changed", self, "_on_value_changed")
+	value = UserSettings.get_setting("video", "ascii_size")
+
+
+func _on_value_changed(value: float) -> void:
+	UserSettings.set_setting("video", "ascii_size", value)

--- a/recursio-client/UI/Menus/FullScreenCheckButton.gd
+++ b/recursio-client/UI/Menus/FullScreenCheckButton.gd
@@ -1,18 +1,11 @@
 extends CheckButton
 
 
-var settings setget set_settings
-
-
-func set_settings(new_settings):
-	settings = new_settings
-	pressed = settings.get_setting("video", "fullscreen")
-
-
 func _ready():
 	connect("toggled", self, "_on_toggled")
+	pressed = UserSettings.get_setting("video", "fullscreen")
 
 
 func _on_toggled(is_enabled):
 	OS.window_fullscreen = is_enabled
-	settings.set_setting("video", "fullscreen", is_enabled)
+	UserSettings.set_setting("video", "fullscreen", is_enabled)

--- a/recursio-client/UI/Menus/FullScreenCheckButton.gd
+++ b/recursio-client/UI/Menus/FullScreenCheckButton.gd
@@ -1,0 +1,18 @@
+extends CheckButton
+
+
+var settings setget set_settings
+
+
+func set_settings(new_settings):
+	settings = new_settings
+	pressed = settings.get_setting("video", "fullscreen")
+
+
+func _ready():
+	connect("toggled", self, "_on_toggled")
+
+
+func _on_toggled(is_enabled):
+	OS.window_fullscreen = is_enabled
+	settings.set_setting("video", "fullscreen", is_enabled)

--- a/recursio-client/UI/Menus/SettingsContainer.gd
+++ b/recursio-client/UI/Menus/SettingsContainer.gd
@@ -1,0 +1,9 @@
+extends PanelContainer
+
+
+func _ready():
+	$SettingsList/BackButton.connect("pressed", self, "_on_back_pressed")
+
+
+func _on_back_pressed():
+	hide()

--- a/recursio-client/UI/Menus/SettingsContainer.gd
+++ b/recursio-client/UI/Menus/SettingsContainer.gd
@@ -1,9 +1,36 @@
 extends PanelContainer
 
+export var always_apply_defaults_at_startup := false
+
+var settings_config = ConfigFile.new()
+
+const SETTINGS_PATH = "user://settings.ini"
+
 
 func _ready():
+	# Load previous settings
+	var err = settings_config.load(SETTINGS_PATH)
+
+	# If the file didn't load (first ever game start), save the defaults there initially
+	if err != OK or always_apply_defaults_at_startup:
+		settings_config.load("res://default-settings.ini") # this should never fail
+		settings_config.save(SETTINGS_PATH)
+	
 	$SettingsList/BackButton.connect("pressed", self, "_on_back_pressed")
+	
+	# Allow nodes which set a setting to access the config via this node
+	for node in get_tree().get_nodes_in_group("Setting"):
+		node.set("settings", self)
 
 
 func _on_back_pressed():
 	hide()
+
+
+func get_setting(setting_header, setting_name, default = null):
+	return settings_config.get_value(setting_header, setting_name, default)
+
+
+func set_setting(setting_header, setting_name, value):
+	settings_config.set_value(setting_header, setting_name, value)
+	settings_config.save(SETTINGS_PATH)

--- a/recursio-client/UI/Menus/SettingsContainer.gd
+++ b/recursio-client/UI/Menus/SettingsContainer.gd
@@ -1,36 +1,9 @@
 extends PanelContainer
 
-export var always_apply_defaults_at_startup := false
-
-var settings_config = ConfigFile.new()
-
-const SETTINGS_PATH = "user://settings.ini"
-
 
 func _ready():
-	# Load previous settings
-	var err = settings_config.load(SETTINGS_PATH)
-
-	# If the file didn't load (first ever game start), save the defaults there initially
-	if err != OK or always_apply_defaults_at_startup:
-		settings_config.load("res://default-settings.ini") # this should never fail
-		settings_config.save(SETTINGS_PATH)
-	
 	$SettingsList/BackButton.connect("pressed", self, "_on_back_pressed")
-	
-	# Allow nodes which set a setting to access the config via this node
-	for node in get_tree().get_nodes_in_group("Setting"):
-		node.set("settings", self)
 
 
 func _on_back_pressed():
 	hide()
-
-
-func get_setting(setting_header, setting_name, default = null):
-	return settings_config.get_value(setting_header, setting_name, default)
-
-
-func set_setting(setting_header, setting_name, value):
-	settings_config.set_value(setting_header, setting_name, value)
-	settings_config.save(SETTINGS_PATH)

--- a/recursio-client/UI/Menus/StartMenu.gd
+++ b/recursio-client/UI/Menus/StartMenu.gd
@@ -13,6 +13,7 @@ onready var _btn_play_tutorial = get_node("CenterContainer/MainMenu/PlayTutorial
 onready var _btn_play_online = get_node("CenterContainer/MainMenu/PlayOnline")
 onready var _btn_play_local = get_node("CenterContainer/MainMenu/HBoxContainer/Btn_PlayLocal")
 onready var _lineEdit_local_ip = get_node("CenterContainer/MainMenu/HBoxContainer/LocalIPAddress")
+onready var _btn_settings = get_node("CenterContainer/MainMenu/SettingsButton")
 onready var _btn_exit = get_node("CenterContainer/MainMenu/Btn_Exit")
 
 onready var _game_room_search: GameRoomSearch = get_node("CenterContainer/GameRoomSearch")
@@ -34,6 +35,7 @@ func _ready():
 	var _error = _btn_play_tutorial.connect("pressed", self, "_on_play_tutorial")
 	_error = _btn_play_online.connect("pressed", self, "_on_play_online")
 	_error = _btn_play_local.connect("pressed", self, "_on_play_local")
+	_error = _btn_settings.connect("pressed", self, "_on_open_settings")
 	_error = _btn_exit.connect("pressed", self, "_on_exit")
 
 	_error = _game_room_search.connect("btn_create_game_room_pressed", self, "_on_search_create_game_room_pressed")
@@ -126,6 +128,10 @@ func _on_play_online() -> void:
 func _on_play_local() -> void:
 	_toggle_enabled_start_menu_buttons(false)
 	Server.connect_to_server(_lineEdit_local_ip.text)
+
+
+func _on_open_settings() -> void:
+	$CenterContainer/SettingsContainer.show()
 
 
 func _on_exit() -> void:

--- a/recursio-client/UI/Menus/StartMenu.tscn
+++ b/recursio-client/UI/Menus/StartMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=2]
+[gd_scene load_steps=23 format=2]
 
 [ext_resource path="res://UI/Menus/StartMenu.gd" type="Script" id=1]
 [ext_resource path="res://UI/Menus/GameRooms/GameRoomCreation.gd" type="Script" id=2]
@@ -13,6 +13,8 @@
 [ext_resource path="res://addons/ascii-shader/character_map.png" type="Texture" id=11]
 [ext_resource path="res://UI/Default.tres" type="Theme" id=12]
 [ext_resource path="res://Resources/Fonts/FiraCode-Regular.ttf" type="DynamicFontData" id=13]
+[ext_resource path="res://UI/Menus/SettingsContainer.gd" type="Script" id=14]
+[ext_resource path="res://UI/Menus/VolumeSlider.gd" type="Script" id=15]
 
 [sub_resource type="Shader" id=1]
 code = "shader_type canvas_item;
@@ -140,9 +142,9 @@ __meta__ = {
 
 [node name="MainMenu" type="VBoxContainer" parent="CenterContainer"]
 margin_left = 812.0
-margin_top = 428.0
+margin_top = 410.0
 margin_right = 1108.0
-margin_bottom = 651.0
+margin_bottom = 669.0
 
 [node name="Label" type="Label" parent="CenterContainer/MainMenu"]
 margin_right = 296.0
@@ -186,10 +188,17 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Btn_Exit" type="Button" parent="CenterContainer/MainMenu"]
+[node name="SettingsButton" type="Button" parent="CenterContainer/MainMenu"]
 margin_top = 191.0
 margin_right = 296.0
 margin_bottom = 223.0
+shortcut_in_tooltip = false
+text = "Settings"
+
+[node name="Btn_Exit" type="Button" parent="CenterContainer/MainMenu"]
+margin_top = 227.0
+margin_right = 296.0
+margin_bottom = 259.0
 shortcut_in_tooltip = false
 text = "Exit"
 
@@ -422,6 +431,136 @@ focus_next = NodePath("../Btn_Ready")
 focus_previous = NodePath("../Btn_Ready")
 shortcut_in_tooltip = false
 text = "Leave"
+
+[node name="SettingsContainer" type="PanelContainer" parent="CenterContainer"]
+margin_left = 643.0
+margin_top = 411.0
+margin_right = 1277.0
+margin_bottom = 669.0
+script = ExtResource( 14 )
+
+[node name="SettingsList" type="VBoxContainer" parent="CenterContainer/SettingsContainer"]
+margin_left = 7.0
+margin_top = 7.0
+margin_right = 627.0
+margin_bottom = 251.0
+
+[node name="Header" type="Label" parent="CenterContainer/SettingsContainer/SettingsList"]
+margin_right = 620.0
+margin_bottom = 26.0
+text = "Settings"
+align = 1
+
+[node name="Space" type="Control" parent="CenterContainer/SettingsContainer/SettingsList"]
+margin_top = 30.0
+margin_right = 620.0
+margin_bottom = 50.0
+rect_min_size = Vector2( 0, 20 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="MainVolume" type="HBoxContainer" parent="CenterContainer/SettingsContainer/SettingsList"]
+margin_top = 54.0
+margin_right = 620.0
+margin_bottom = 80.0
+
+[node name="Label" type="Label" parent="CenterContainer/SettingsContainer/SettingsList/MainVolume"]
+margin_right = 156.0
+margin_bottom = 26.0
+text = "Main Volume: "
+
+[node name="VolumeSlider" type="HSlider" parent="CenterContainer/SettingsContainer/SettingsList/MainVolume"]
+margin_left = 160.0
+margin_right = 560.0
+margin_bottom = 16.0
+rect_min_size = Vector2( 400, 0 )
+max_value = 1.0
+step = 0.05
+value = 1.0
+tick_count = 11
+ticks_on_borders = true
+script = ExtResource( 15 )
+
+[node name="MusicVolume" type="HBoxContainer" parent="CenterContainer/SettingsContainer/SettingsList"]
+margin_top = 84.0
+margin_right = 620.0
+margin_bottom = 110.0
+
+[node name="Label" type="Label" parent="CenterContainer/SettingsContainer/SettingsList/MusicVolume"]
+margin_right = 192.0
+margin_bottom = 26.0
+text = "  Music Volume: "
+
+[node name="VolumeSlider" type="HSlider" parent="CenterContainer/SettingsContainer/SettingsList/MusicVolume"]
+margin_left = 196.0
+margin_right = 596.0
+margin_bottom = 16.0
+rect_min_size = Vector2( 400, 0 )
+max_value = 1.0
+step = 0.05
+value = 1.0
+tick_count = 11
+ticks_on_borders = true
+script = ExtResource( 15 )
+audio_bus_name = "Music"
+
+[node name="EffectsVolume" type="HBoxContainer" parent="CenterContainer/SettingsContainer/SettingsList"]
+margin_top = 114.0
+margin_right = 620.0
+margin_bottom = 140.0
+
+[node name="Label" type="Label" parent="CenterContainer/SettingsContainer/SettingsList/EffectsVolume"]
+margin_right = 216.0
+margin_bottom = 26.0
+text = "  Effects Volume: "
+
+[node name="VolumeSlider" type="HSlider" parent="CenterContainer/SettingsContainer/SettingsList/EffectsVolume"]
+margin_left = 220.0
+margin_right = 620.0
+margin_bottom = 16.0
+rect_min_size = Vector2( 400, 0 )
+max_value = 1.0
+step = 0.05
+value = 1.0
+tick_count = 11
+ticks_on_borders = true
+script = ExtResource( 15 )
+audio_bus_name = "Effects"
+
+[node name="FullScreen" type="HBoxContainer" parent="CenterContainer/SettingsContainer/SettingsList"]
+margin_top = 144.0
+margin_right = 620.0
+margin_bottom = 184.0
+
+[node name="Label" type="Label" parent="CenterContainer/SettingsContainer/SettingsList/FullScreen"]
+margin_top = 7.0
+margin_right = 156.0
+margin_bottom = 33.0
+text = "Full Screen: "
+
+[node name="CheckButton" type="CheckButton" parent="CenterContainer/SettingsContainer/SettingsList/FullScreen"]
+margin_left = 160.0
+margin_right = 236.0
+margin_bottom = 40.0
+
+[node name="Space2" type="Control" parent="CenterContainer/SettingsContainer/SettingsList"]
+margin_top = 188.0
+margin_right = 620.0
+margin_bottom = 208.0
+rect_min_size = Vector2( 0, 20 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="BackButton" type="Button" parent="CenterContainer/SettingsContainer/SettingsList"]
+margin_top = 212.0
+margin_right = 620.0
+margin_bottom = 244.0
+text = "Back"
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="StatsHUD" type="Control" parent="."]
 anchor_right = 1.0

--- a/recursio-client/UI/Menus/StartMenu.tscn
+++ b/recursio-client/UI/Menus/StartMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=24 format=2]
+[gd_scene load_steps=26 format=2]
 
 [ext_resource path="res://UI/Menus/StartMenu.gd" type="Script" id=1]
 [ext_resource path="res://UI/Menus/GameRooms/GameRoomCreation.gd" type="Script" id=2]
@@ -16,6 +16,8 @@
 [ext_resource path="res://UI/Menus/SettingsContainer.gd" type="Script" id=14]
 [ext_resource path="res://UI/Menus/VolumeSlider.gd" type="Script" id=15]
 [ext_resource path="res://UI/Menus/FullScreenCheckButton.gd" type="Script" id=16]
+[ext_resource path="res://UI/Menus/AsciiSlider.gd" type="Script" id=17]
+[ext_resource path="res://UI/Menus/AsciiBackground.gd" type="Script" id=18]
 
 [sub_resource type="Shader" id=1]
 code = "shader_type canvas_item;
@@ -126,10 +128,11 @@ world_scene = ExtResource( 7 )
 level_scene = ExtResource( 9 )
 capture_point_scene = ExtResource( 10 )
 
-[node name="ColorRect" type="ColorRect" parent="."]
+[node name="AsciiBackground" type="ColorRect" parent="."]
 material = SubResource( 6 )
 anchor_right = 1.0
 anchor_bottom = 1.0
+script = ExtResource( 18 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -434,28 +437,28 @@ shortcut_in_tooltip = false
 text = "Leave"
 
 [node name="SettingsContainer" type="PanelContainer" parent="CenterContainer"]
-visible = false
-margin_left = 953.0
-margin_top = 533.0
-margin_right = 967.0
-margin_bottom = 547.0
+margin_left = 635.0
+margin_top = 396.0
+margin_right = 1285.0
+margin_bottom = 684.0
+rect_min_size = Vector2( 650, 0 )
 script = ExtResource( 14 )
 
 [node name="SettingsList" type="VBoxContainer" parent="CenterContainer/SettingsContainer"]
 margin_left = 7.0
 margin_top = 7.0
-margin_right = 627.0
-margin_bottom = 251.0
+margin_right = 643.0
+margin_bottom = 281.0
 
 [node name="Header" type="Label" parent="CenterContainer/SettingsContainer/SettingsList"]
-margin_right = 620.0
+margin_right = 636.0
 margin_bottom = 26.0
 text = "Settings"
 align = 1
 
 [node name="Space" type="Control" parent="CenterContainer/SettingsContainer/SettingsList"]
 margin_top = 30.0
-margin_right = 620.0
+margin_right = 636.0
 margin_bottom = 50.0
 rect_min_size = Vector2( 0, 20 )
 __meta__ = {
@@ -464,7 +467,7 @@ __meta__ = {
 
 [node name="MainVolume" type="HBoxContainer" parent="CenterContainer/SettingsContainer/SettingsList"]
 margin_top = 54.0
-margin_right = 620.0
+margin_right = 636.0
 margin_bottom = 80.0
 
 [node name="Label" type="Label" parent="CenterContainer/SettingsContainer/SettingsList/MainVolume"]
@@ -474,9 +477,10 @@ text = "Main Volume: "
 
 [node name="VolumeSlider" type="HSlider" parent="CenterContainer/SettingsContainer/SettingsList/MainVolume" groups=["Setting"]]
 margin_left = 160.0
-margin_right = 560.0
+margin_right = 636.0
 margin_bottom = 16.0
 rect_min_size = Vector2( 400, 0 )
+size_flags_horizontal = 3
 max_value = 1.0
 step = 0.05
 value = 1.0
@@ -486,7 +490,7 @@ script = ExtResource( 15 )
 
 [node name="MusicVolume" type="HBoxContainer" parent="CenterContainer/SettingsContainer/SettingsList"]
 margin_top = 84.0
-margin_right = 620.0
+margin_right = 636.0
 margin_bottom = 110.0
 
 [node name="Label" type="Label" parent="CenterContainer/SettingsContainer/SettingsList/MusicVolume"]
@@ -496,9 +500,10 @@ text = "  Music Volume: "
 
 [node name="VolumeSlider" type="HSlider" parent="CenterContainer/SettingsContainer/SettingsList/MusicVolume" groups=["Setting"]]
 margin_left = 196.0
-margin_right = 596.0
+margin_right = 636.0
 margin_bottom = 16.0
 rect_min_size = Vector2( 400, 0 )
+size_flags_horizontal = 3
 max_value = 1.0
 step = 0.05
 value = 1.0
@@ -509,7 +514,7 @@ audio_bus_name = "Music"
 
 [node name="EffectsVolume" type="HBoxContainer" parent="CenterContainer/SettingsContainer/SettingsList"]
 margin_top = 114.0
-margin_right = 620.0
+margin_right = 636.0
 margin_bottom = 140.0
 
 [node name="Label" type="Label" parent="CenterContainer/SettingsContainer/SettingsList/EffectsVolume"]
@@ -519,9 +524,10 @@ text = "  Effects Volume: "
 
 [node name="VolumeSlider" type="HSlider" parent="CenterContainer/SettingsContainer/SettingsList/EffectsVolume" groups=["Setting"]]
 margin_left = 220.0
-margin_right = 620.0
+margin_right = 636.0
 margin_bottom = 16.0
 rect_min_size = Vector2( 400, 0 )
+size_flags_horizontal = 3
 max_value = 1.0
 step = 0.05
 value = 1.0
@@ -532,7 +538,7 @@ audio_bus_name = "Effects"
 
 [node name="FullScreen" type="HBoxContainer" parent="CenterContainer/SettingsContainer/SettingsList"]
 margin_top = 144.0
-margin_right = 620.0
+margin_right = 636.0
 margin_bottom = 184.0
 
 [node name="Label" type="Label" parent="CenterContainer/SettingsContainer/SettingsList/FullScreen"]
@@ -547,19 +553,42 @@ margin_right = 236.0
 margin_bottom = 40.0
 script = ExtResource( 16 )
 
-[node name="Space2" type="Control" parent="CenterContainer/SettingsContainer/SettingsList"]
+[node name="AsciiSize" type="HBoxContainer" parent="CenterContainer/SettingsContainer/SettingsList"]
 margin_top = 188.0
-margin_right = 620.0
-margin_bottom = 208.0
+margin_right = 636.0
+margin_bottom = 214.0
+
+[node name="Label" type="Label" parent="CenterContainer/SettingsContainer/SettingsList/AsciiSize"]
+margin_right = 264.0
+margin_bottom = 26.0
+text = "ASCII Character Size: "
+
+[node name="AsciiSlider" type="HSlider" parent="CenterContainer/SettingsContainer/SettingsList/AsciiSize"]
+margin_left = 268.0
+margin_right = 636.0
+margin_bottom = 16.0
+size_flags_horizontal = 3
+min_value = 4.0
+max_value = 16.0
+step = 4.0
+value = 8.0
+tick_count = 4
+ticks_on_borders = true
+script = ExtResource( 17 )
+
+[node name="Space2" type="Control" parent="CenterContainer/SettingsContainer/SettingsList"]
+margin_top = 218.0
+margin_right = 636.0
+margin_bottom = 238.0
 rect_min_size = Vector2( 0, 20 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="BackButton" type="Button" parent="CenterContainer/SettingsContainer/SettingsList"]
-margin_top = 212.0
-margin_right = 620.0
-margin_bottom = 244.0
+margin_top = 242.0
+margin_right = 636.0
+margin_bottom = 274.0
 text = "Back"
 __meta__ = {
 "_edit_use_anchors_": false

--- a/recursio-client/UI/Menus/StartMenu.tscn
+++ b/recursio-client/UI/Menus/StartMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=23 format=2]
+[gd_scene load_steps=24 format=2]
 
 [ext_resource path="res://UI/Menus/StartMenu.gd" type="Script" id=1]
 [ext_resource path="res://UI/Menus/GameRooms/GameRoomCreation.gd" type="Script" id=2]
@@ -15,6 +15,7 @@
 [ext_resource path="res://Resources/Fonts/FiraCode-Regular.ttf" type="DynamicFontData" id=13]
 [ext_resource path="res://UI/Menus/SettingsContainer.gd" type="Script" id=14]
 [ext_resource path="res://UI/Menus/VolumeSlider.gd" type="Script" id=15]
+[ext_resource path="res://UI/Menus/FullScreenCheckButton.gd" type="Script" id=16]
 
 [sub_resource type="Shader" id=1]
 code = "shader_type canvas_item;
@@ -433,10 +434,11 @@ shortcut_in_tooltip = false
 text = "Leave"
 
 [node name="SettingsContainer" type="PanelContainer" parent="CenterContainer"]
-margin_left = 643.0
-margin_top = 411.0
-margin_right = 1277.0
-margin_bottom = 669.0
+visible = false
+margin_left = 953.0
+margin_top = 533.0
+margin_right = 967.0
+margin_bottom = 547.0
 script = ExtResource( 14 )
 
 [node name="SettingsList" type="VBoxContainer" parent="CenterContainer/SettingsContainer"]
@@ -470,7 +472,7 @@ margin_right = 156.0
 margin_bottom = 26.0
 text = "Main Volume: "
 
-[node name="VolumeSlider" type="HSlider" parent="CenterContainer/SettingsContainer/SettingsList/MainVolume"]
+[node name="VolumeSlider" type="HSlider" parent="CenterContainer/SettingsContainer/SettingsList/MainVolume" groups=["Setting"]]
 margin_left = 160.0
 margin_right = 560.0
 margin_bottom = 16.0
@@ -492,7 +494,7 @@ margin_right = 192.0
 margin_bottom = 26.0
 text = "  Music Volume: "
 
-[node name="VolumeSlider" type="HSlider" parent="CenterContainer/SettingsContainer/SettingsList/MusicVolume"]
+[node name="VolumeSlider" type="HSlider" parent="CenterContainer/SettingsContainer/SettingsList/MusicVolume" groups=["Setting"]]
 margin_left = 196.0
 margin_right = 596.0
 margin_bottom = 16.0
@@ -515,7 +517,7 @@ margin_right = 216.0
 margin_bottom = 26.0
 text = "  Effects Volume: "
 
-[node name="VolumeSlider" type="HSlider" parent="CenterContainer/SettingsContainer/SettingsList/EffectsVolume"]
+[node name="VolumeSlider" type="HSlider" parent="CenterContainer/SettingsContainer/SettingsList/EffectsVolume" groups=["Setting"]]
 margin_left = 220.0
 margin_right = 620.0
 margin_bottom = 16.0
@@ -539,10 +541,11 @@ margin_right = 156.0
 margin_bottom = 33.0
 text = "Full Screen: "
 
-[node name="CheckButton" type="CheckButton" parent="CenterContainer/SettingsContainer/SettingsList/FullScreen"]
+[node name="FullScreenCheckButton" type="CheckButton" parent="CenterContainer/SettingsContainer/SettingsList/FullScreen" groups=["Setting"]]
 margin_left = 160.0
 margin_right = 236.0
 margin_bottom = 40.0
+script = ExtResource( 16 )
 
 [node name="Space2" type="Control" parent="CenterContainer/SettingsContainer/SettingsList"]
 margin_top = 188.0

--- a/recursio-client/UI/Menus/StartMenu.tscn
+++ b/recursio-client/UI/Menus/StartMenu.tscn
@@ -437,10 +437,11 @@ shortcut_in_tooltip = false
 text = "Leave"
 
 [node name="SettingsContainer" type="PanelContainer" parent="CenterContainer"]
+visible = false
 margin_left = 635.0
-margin_top = 396.0
+margin_top = 533.0
 margin_right = 1285.0
-margin_bottom = 684.0
+margin_bottom = 547.0
 rect_min_size = Vector2( 650, 0 )
 script = ExtResource( 14 )
 

--- a/recursio-client/UI/Menus/VolumeSlider.gd
+++ b/recursio-client/UI/Menus/VolumeSlider.gd
@@ -5,12 +5,18 @@ export var audio_bus_name := "Master"
 
 onready var _bus := AudioServer.get_bus_index(audio_bus_name)
 
+var settings setget set_settings
+
 
 func _ready() -> void:
-	value = db2linear(AudioServer.get_bus_volume_db(_bus))
 	connect("value_changed", self, "_on_value_changed")
 
 
 func _on_value_changed(value: float) -> void:
 	AudioServer.set_bus_volume_db(_bus, linear2db(value))
-	# TODO: Save this value!
+	settings.set_setting("audio", audio_bus_name.to_lower() + "_volume", value)
+
+
+func set_settings(new_settings):
+	settings = new_settings
+	value = settings.get_setting("audio", audio_bus_name.to_lower() + "_volume")

--- a/recursio-client/UI/Menus/VolumeSlider.gd
+++ b/recursio-client/UI/Menus/VolumeSlider.gd
@@ -5,18 +5,12 @@ export var audio_bus_name := "Master"
 
 onready var _bus := AudioServer.get_bus_index(audio_bus_name)
 
-var settings setget set_settings
-
 
 func _ready() -> void:
 	connect("value_changed", self, "_on_value_changed")
+	value = UserSettings.get_setting("audio", audio_bus_name.to_lower() + "_volume")
 
 
 func _on_value_changed(value: float) -> void:
 	AudioServer.set_bus_volume_db(_bus, linear2db(value))
-	settings.set_setting("audio", audio_bus_name.to_lower() + "_volume", value)
-
-
-func set_settings(new_settings):
-	settings = new_settings
-	value = settings.get_setting("audio", audio_bus_name.to_lower() + "_volume")
+	UserSettings.set_setting("audio", audio_bus_name.to_lower() + "_volume", value)

--- a/recursio-client/UI/Menus/VolumeSlider.gd
+++ b/recursio-client/UI/Menus/VolumeSlider.gd
@@ -1,0 +1,16 @@
+extends HSlider
+
+
+export var audio_bus_name := "Master"
+
+onready var _bus := AudioServer.get_bus_index(audio_bus_name)
+
+
+func _ready() -> void:
+	value = db2linear(AudioServer.get_bus_volume_db(_bus))
+	connect("value_changed", self, "_on_value_changed")
+
+
+func _on_value_changed(value: float) -> void:
+	AudioServer.set_bus_volume_db(_bus, linear2db(value))
+	# TODO: Save this value!

--- a/recursio-client/default-settings.ini
+++ b/recursio-client/default-settings.ini
@@ -1,0 +1,7 @@
+[audio]
+master_volume=0.8
+music_volume=1.0
+effects_volume=1.0
+
+[video]
+fullscreen=false

--- a/recursio-client/default-settings.ini
+++ b/recursio-client/default-settings.ini
@@ -5,3 +5,4 @@ effects_volume=1.0
 
 [video]
 fullscreen=false
+ascii_size=8

--- a/recursio-client/default_bus_layout.tres
+++ b/recursio-client/default_bus_layout.tres
@@ -1,0 +1,15 @@
+[gd_resource type="AudioBusLayout" format=2]
+
+[resource]
+bus/1/name = "Music"
+bus/1/solo = false
+bus/1/mute = false
+bus/1/bypass_fx = false
+bus/1/volume_db = 0.0
+bus/1/send = "Master"
+bus/2/name = "Effects"
+bus/2/solo = false
+bus/2/mute = false
+bus/2/bypass_fx = false
+bus/2/volume_db = 0.0
+bus/2/send = "Master"

--- a/recursio-client/project.godot
+++ b/recursio-client/project.godot
@@ -251,6 +251,7 @@ LoggerPluginSingleton="*res://addons/recursio-loggerplugin/LoggerPluginSingleton
 Server="*res://Global/Server.gd"
 InputManager="*res://Global/InputManager.gd"
 GlobalActionManager="*res://Shared/Actions/ActionManager.gd"
+UserSettings="*res://Global/UserSettings.gd"
 
 [debug]
 


### PR DESCRIPTION
# Overview
The global `UserSettings` is responsible for keeping track of persistent user settings. Sliders, checkboxes, etc. should use `UserSettings.get_setting` and `set_setting` for setting their initial value and persisting new values. Other nodes can call `UserSettings.get_setting` and subscribe to `UserSettings.setting_changed` to react to changes.

# Progress
- [X] Volume (#145)
    - [X]  Effects and music
- [X] Full Screen
- [ ] Colors (#143)
- [ ] Controls (#141)
- [x] ASCII resolution
- [ ] General resolution
- [ ] Toggle stats  like FPS, Latency and maybe even more! (mostly for debugging but players like it as well)

(@incredibleLeitman @AmonShokhinAhmed @DavidPgl feel free to add ideas to this list)

![image](https://user-images.githubusercontent.com/18697097/144643641-022d58fd-eaa0-4a8d-949c-e980c9603e14.png)
