### PR TITLE
More robust timeline picks

### DIFF
--- a/Shared/Characters/CharacterBase.gd
+++ b/Shared/Characters/CharacterBase.gd
@@ -110,8 +110,9 @@ func set_velocity(new_velocity):
 
 
 func set_timeline_index(new_timeline_index: int):
-	timeline_index = new_timeline_index
-	emit_signal("timeline_index_changed", new_timeline_index)
+	if timeline_index != new_timeline_index:
+		timeline_index = new_timeline_index
+		emit_signal("timeline_index_changed", new_timeline_index)
 
 func hit(perpetrator) -> void:
 	emit_signal("hit", perpetrator)

--- a/recursio-client/Global/Server.gd
+++ b/recursio-client/Global/Server.gd
@@ -30,7 +30,7 @@ signal game_result(winning_player_id)
 signal player_hit(hit_player_id, perpetrator_player_id, perpetrator_timeline_index)
 signal ghost_hit(hit_ghost_player_owner, hit_ghost_id, perpetrator_player_id, perpetrator_timeline_index)
 signal quiet_ghost_hit(hit_ghost_player_owner, hit_ghost_id, perpetrator_player_id, perpetrator_timeline_index)
-signal timeline_pick(picking_player_id, timeline_index)
+signal timeline_picked(picking_player_id, timeline_index)
 signal wall_spawn (position, rotation, wall_index)
 
 signal phase_switch_received(round_index,next_phase, switch_time)
@@ -267,7 +267,7 @@ remote func receive_player_action(action_player_id, action_type):
 
 remote func receive_timeline_pick(picking_player_id, timeline_index):
 	Logger.debug("Ghost pick received", "server")
-	emit_signal("timeline_pick",picking_player_id, timeline_index)
+	emit_signal("timeline_picked",picking_player_id, timeline_index)
 
 
 remote func receive_wall_spawn(position, rotation, wall_index):

--- a/recursio-client/Global/Server.gd
+++ b/recursio-client/Global/Server.gd
@@ -30,7 +30,7 @@ signal game_result(winning_player_id)
 signal player_hit(hit_player_id, perpetrator_player_id, perpetrator_timeline_index)
 signal ghost_hit(hit_ghost_player_owner, hit_ghost_id, perpetrator_player_id, perpetrator_timeline_index)
 signal quiet_ghost_hit(hit_ghost_player_owner, hit_ghost_id, perpetrator_player_id, perpetrator_timeline_index)
-signal timeline_picks(player_pick, enemy_picks)
+signal timeline_pick(picking_player_id, timeline_index)
 signal wall_spawn (position, rotation, wall_index)
 
 signal phase_switch_received(round_index,next_phase, switch_time)
@@ -265,9 +265,9 @@ remote func receive_player_action(action_player_id, action_type):
 	emit_signal("player_action", action_player_id, action_type)
 
 
-remote func receive_timeline_picks(player_pick, enemy_pick):
-	Logger.debug("Ghost picks received", "server")
-	emit_signal("timeline_picks",player_pick, enemy_pick)
+remote func receive_timeline_pick(picking_player_id, timeline_index):
+	Logger.debug("Ghost pick received", "server")
+	emit_signal("timeline_pick",picking_player_id, timeline_index)
 
 
 remote func receive_wall_spawn(position, rotation, wall_index):

--- a/recursio-client/Managers/CharacterManager.gd
+++ b/recursio-client/Managers/CharacterManager.gd
@@ -50,7 +50,7 @@ func _ready():
 	_error = Server.connect("world_state_received", self, "_on_world_state_received") 
 	_error = Server.connect("player_hit", self, "_on_player_hit") 
 
-	_error = Server.connect("timeline_picks", self, "_on_timeline_picks") 
+	_error = Server.connect("timeline_pick", self, "_on_timeline_pick") 
 
 	_error = Server.connect("capture_point_captured", self, "_on_capture_point_captured") 
 	_error = Server.connect("capture_point_capture_lost", self, "_on_capture_point_capture_lost")
@@ -204,9 +204,9 @@ func _on_enemy_timeline_changed(timeline_index) -> void:
 	_ghost_manager.refresh_active_ghosts()
 	_ghost_manager.refresh_path_select()
 
-func _on_timeline_picks(player_pick, enemy_pick):
-	_enemy.timeline_index = enemy_pick
-	_player.timeline_index = player_pick
+func _on_timeline_pick(picking_player_id, timeline_index):
+	var character = _player if _player.player_id == picking_player_id else _enemy
+	character.timeline_index = timeline_index
 	_ghost_manager.refresh_active_ghosts()
 	_ghost_manager.refresh_path_select()
 

--- a/recursio-client/Managers/CharacterManager.gd
+++ b/recursio-client/Managers/CharacterManager.gd
@@ -50,7 +50,7 @@ func _ready():
 	_error = Server.connect("world_state_received", self, "_on_world_state_received") 
 	_error = Server.connect("player_hit", self, "_on_player_hit") 
 
-	_error = Server.connect("timeline_pick", self, "_on_timeline_pick") 
+	_error = Server.connect("timeline_picked", self, "_on_timeline_picked") 
 
 	_error = Server.connect("capture_point_captured", self, "_on_capture_point_captured") 
 	_error = Server.connect("capture_point_capture_lost", self, "_on_capture_point_capture_lost")
@@ -204,7 +204,7 @@ func _on_enemy_timeline_changed(timeline_index) -> void:
 	_ghost_manager.refresh_active_ghosts()
 	_ghost_manager.refresh_path_select()
 
-func _on_timeline_pick(picking_player_id, timeline_index):
+func _on_timeline_picked(picking_player_id, timeline_index):
 	var character = _player if _player.player_id == picking_player_id else _enemy
 	character.timeline_index = timeline_index
 	_ghost_manager.refresh_active_ghosts()

--- a/recursio-client/Managers/CharacterManager.gd
+++ b/recursio-client/Managers/CharacterManager.gd
@@ -193,6 +193,9 @@ func _on_player_timeline_changed(timeline_index) -> void:
 	_ghost_manager.refresh_active_ghosts()
 	_ghost_manager.refresh_path_select()
 	
+	# Client driven timeline changes are only allowed during prep phase, 
+	# so we catch any race condition triggered changes outside the prep phase here
+	# (Should not happen if latency and lag is minimal)
 	if _round_manager.get_current_phase() == RoundManager.Phases.PREPARATION:
 	# Send currently selected timeline to server
 		if Server.is_connection_active:

--- a/recursio-server/GameRoom/CharacterManager.gd
+++ b/recursio-server/GameRoom/CharacterManager.gd
@@ -76,7 +76,6 @@ func spawn_player(player_id, team_id, player_user_name) -> void:
 	player.player_id = player_id
 	player.user_name = player_user_name
 	player.team_id = team_id
-	player.timeline_index = 0
 	player.spawn_point = spawn_point
 	add_child(player)
 	var _error = player.connect("hit", self, "_on_player_hit", [player_id])
@@ -92,6 +91,7 @@ func spawn_player(player_id, team_id, player_user_name) -> void:
 	player_dic[player_id] = player
 	player.move_to_spawn_point()
 	Server.spawn_player_on_client(player_id, spawn_point, team_id)
+	player.connect("timeline_index_changed", self, "_on_player_timeline_changed", [player.player_id])
 
 func reset_wall_indices():
 	for player_id in player_dic:
@@ -107,17 +107,12 @@ func set_timeline_index(player_id, timeline_index):
 	player.timeline_index = timeline_index
 	player.spawn_point = _game_manager.get_spawn_point(player.team_id, timeline_index).global_transform.origin
 	player.move_to_spawn_point()	
-	propagate_player_picks()
 
-func propagate_player_picks():
-	Logger.info("Propagating timeline picks", "ghost_picking")
-	for player_id in player_dic:
-		var player_pick = player_dic[player_id].timeline_index
-		var enemy_pick
-		for enemy_id in player_dic:
-			if enemy_id != player_id:
-				enemy_pick = player_dic[enemy_id].timeline_index
-		Server.send_timeline_pick(player_id, player_pick, enemy_pick)
+
+func _on_player_timeline_changed(timeline_index, picking_player_id):
+	for client_id in player_dic:
+		Server.send_timeline_pick(client_id, picking_player_id, timeline_index)
+
 
 func _on_player_hit(perpetrator, victim_player_id):
 	Logger.info("Player hit!", "attacking")

--- a/recursio-server/GameRoom/CharacterManager.gd
+++ b/recursio-server/GameRoom/CharacterManager.gd
@@ -110,6 +110,15 @@ func set_timeline_index(player_id, timeline_index):
 
 
 func _on_player_timeline_changed(timeline_index, picking_player_id):
+	_propagate_timeline_pick(timeline_index, picking_player_id)
+
+
+func propagate_current_timelines():
+	for player_id in player_dic:
+		_propagate_timeline_pick(player_dic[player_id].timeline_index, player_id)
+
+
+func _propagate_timeline_pick(timeline_index, picking_player_id):
 	for client_id in player_dic:
 		Server.send_timeline_pick(client_id, picking_player_id, timeline_index)
 

--- a/recursio-server/GameRoom/CharacterManager.gd
+++ b/recursio-server/GameRoom/CharacterManager.gd
@@ -103,9 +103,11 @@ func set_block_player_input(blocked: bool) -> void:
 
 func set_timeline_index(player_id, timeline_index):
 	Logger.info("Setting timeline index for player "+str(player_id)+" to "+str(timeline_index),"ghost_picking")
-	player_dic[player_id].timeline_index = timeline_index
-	player_dic[player_id].spawn_point = _game_manager.get_spawn_point(player_dic[player_id].team_id, timeline_index).global_transform.origin
-	player_dic[player_id].move_to_spawn_point()
+	var player = player_dic[player_id]
+	player.timeline_index = timeline_index
+	player.spawn_point = _game_manager.get_spawn_point(player.team_id, timeline_index).global_transform.origin
+	player.move_to_spawn_point()	
+	propagate_player_picks()
 
 func propagate_player_picks():
 	Logger.info("Propagating timeline picks", "ghost_picking")
@@ -115,7 +117,7 @@ func propagate_player_picks():
 		for enemy_id in player_dic:
 			if enemy_id != player_id:
 				enemy_pick = player_dic[enemy_id].timeline_index
-		Server.send_ghost_pick(player_id, player_pick, enemy_pick)
+		Server.send_timeline_pick(player_id, player_pick, enemy_pick)
 
 func _on_player_hit(perpetrator, victim_player_id):
 	Logger.info("Player hit!", "attacking")

--- a/recursio-server/GameRoom/GameRoomWorld.gd
+++ b/recursio-server/GameRoom/GameRoomWorld.gd
@@ -85,8 +85,8 @@ func handle_player_ready(player_id):
 
 
 func handle_ghost_pick(player_id, timeline_index):
-	if _round_manager.get_current_phase() != RoundManager.Phases.COUNTDOWN:
-		Logger.error("Received timeline picks outside proper phase", "ghost_picking")
+	if _round_manager.get_current_phase() == RoundManager.Phases.GAME:
+		Logger.error("Received timeline picks during game phase", "ghost_picking")
 		return
 	_character_manager.set_timeline_index(player_id, timeline_index)
 	_ghost_manager.refresh_active_ghosts()
@@ -134,7 +134,6 @@ func _on_game_phase_started() -> void:
 	var switch_time = _round_manager.get_deadline()
 	for player_id in _character_manager.player_dic:
 		_server.send_phase_switch_to_client(player_id, round_index, RoundManager.Phases.PREPARATION, switch_time)
-	_character_manager.propagate_player_picks()
 	_character_manager.move_players_to_spawn_point()
 	_character_manager.set_block_player_input(false)
 	_ghost_manager.on_game_phase_started()

--- a/recursio-server/GameRoom/GameRoomWorld.gd
+++ b/recursio-server/GameRoom/GameRoomWorld.gd
@@ -130,6 +130,7 @@ func _on_countdown_phase_started():
 	_ghost_manager.on_countdown_phase_started()
 	
 func _on_game_phase_started() -> void:
+	_character_manager.propagate_current_timelines()
 	var round_index = _round_manager.round_index
 	var switch_time = _round_manager.get_deadline()
 	for player_id in _character_manager.player_dic:

--- a/recursio-server/Globals/Server.gd
+++ b/recursio-server/Globals/Server.gd
@@ -127,7 +127,7 @@ func send_quiet_ghost_hit(player_id, victim_player_id, victim_timeline_index, pe
 	rpc_id(player_id, "receive_quiet_ghost_hit", victim_player_id, victim_timeline_index, perpetrator_player_id, perpetrator_timeline_index)
 
 
-func send_ghost_pick(player_id, player_pick, enemy_pick):
+func send_timeline_pick(player_id, player_pick, enemy_pick):
 	Logger.info("Sending ghost picks", "connection")
 	rpc_id(player_id, "receive_timeline_picks", player_pick, enemy_pick)
 

--- a/recursio-server/Globals/Server.gd
+++ b/recursio-server/Globals/Server.gd
@@ -127,9 +127,9 @@ func send_quiet_ghost_hit(player_id, victim_player_id, victim_timeline_index, pe
 	rpc_id(player_id, "receive_quiet_ghost_hit", victim_player_id, victim_timeline_index, perpetrator_player_id, perpetrator_timeline_index)
 
 
-func send_timeline_pick(player_id, player_pick, enemy_pick):
+func send_timeline_pick(player_id, picking_player_id, timeline_index):
 	Logger.info("Sending ghost picks", "connection")
-	rpc_id(player_id, "receive_timeline_picks", player_pick, enemy_pick)
+	rpc_id(player_id, "receive_timeline_pick", picking_player_id, timeline_index)
 
 func send_wall_spawn(position, rotation, wall_index, player_id):
 	Logger.info("Sending wall spawn", "connection")


### PR DESCRIPTION
Changing timelines client side now will be immediately communicated to the server and propagated to the other player. This should make picking more stable (especially when the player decides early in the prep phase). There might still be some glitchy behaviour when picks happen very shortly before phase switches (as the server locks client side picking during the gamephase) but I don't really think we can do much about that. It should be guaranteed though that server and client are always in a consistent state during the game phase.