### PR TITLE
Improve ghost path styling

### DIFF
--- a/recursio-client/Characters/PlayerGhost.gd
+++ b/recursio-client/Characters/PlayerGhost.gd
@@ -16,7 +16,7 @@ func toggle_visibility_light(value: bool):
 func create_path():
 	assert(is_record_data_set())
 	var _curve = Curve3D.new()
-	for frame in range(0, _record_data.record_frames.size(), 30):
+	for frame in range(0, _record_data.record_frames.size(), 15):
 		var record_frame: RecordFrame = _record_data.record_frames[frame]
 		_curve.add_point(record_frame.position)
 	$GhostPath.set_curve(_curve)

--- a/recursio-client/Rendering/GhostPath.gd
+++ b/recursio-client/Rendering/GhostPath.gd
@@ -13,15 +13,13 @@ func _set_selected(new_selected:bool):
 	selected = new_selected
 	change_color()
 
+
 func _set_index(new_index:int):
 	index = new_index
 	change_color()
 
+
 func change_color():
-	var color_name = "neutral"
-	if not selected:
-		var color_scheme = "player_ghost_"
-		var wall_index = Constants.get_value("ghosts","wall_placing_timeline_index")
-		var accent_type = "primary_accent" if wall_index != index else "secondary_accent"
-		color_name = color_scheme+accent_type
-	ColorManager.color_object_by_property(color_name, $Path/CSGPolygon.material_override, "albedo_color")
+	var color_name = "player_ghost_secondary_accent" if selected else "unselected"
+	transform.origin.y = 0.5 if selected else 0.0 # Make sure this path is on top
+	ColorManager.color_object_by_property(color_name, $Path/PathCSGPolygon, "color")

--- a/recursio-client/Rendering/GhostPath.tscn
+++ b/recursio-client/Rendering/GhostPath.tscn
@@ -1,11 +1,57 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://Rendering/GhostPath.gd" type="Script" id=1]
+[ext_resource path="res://Rendering/PathCSGPolygon.gd" type="Script" id=3]
 
-[sub_resource type="SpatialMaterial" id=1]
+[sub_resource type="Shader" id=1]
+code = "// NOTE: Shader automatically converted from Godot Engine 3.4.stable's SpatialMaterial.
+
+shader_type spatial;
+render_mode blend_mix,depth_draw_opaque,cull_back,diffuse_burley,specular_schlick_ggx,unshaded;
+uniform vec4 color : hint_color;
+uniform float specular;
+uniform float metallic;
+uniform float roughness : hint_range(0,1);
+uniform float point_size : hint_range(0,128);
+uniform vec3 uv1_scale;
+uniform vec3 uv1_offset;
+uniform vec3 uv2_scale;
+uniform vec3 uv2_offset;
+
+
+void vertex() {
+	UV=UV*uv1_scale.xy+uv1_offset.xy;
+}
+
+
+
+
+void fragment() {
+	vec2 base_uv = UV;
+	ALBEDO = color.rgb;
+	METALLIC = metallic;
+	ROUGHNESS = roughness;
+	SPECULAR = specular;
+	
+	// Fade out towards the end, but add \"waves\" in the direction of flow
+	float fade_out_factor = (1.5 - UV.x);
+	fade_out_factor += sin(-UV.x * 70.0 + TIME * 7.0) * 0.3;
+	ALBEDO *= fade_out_factor;
+}
+"
+
+[sub_resource type="ShaderMaterial" id=2]
 resource_local_to_scene = true
-flags_unshaded = true
-albedo_color = Color( 0.231373, 1, 0, 1 )
+shader = SubResource( 1 )
+shader_param/color = Color( 1, 0.627451, 0.627451, 1 )
+shader_param/specular = 0.5
+shader_param/metallic = 0.0
+shader_param/roughness = 1.0
+shader_param/point_size = 1.0
+shader_param/uv1_scale = Vector3( 1, 1, 1 )
+shader_param/uv1_offset = Vector3( 0, 0, 0 )
+shader_param/uv2_scale = Vector3( 1, 1, 1 )
+shader_param/uv2_offset = Vector3( 0, 0, 0 )
 
 [node name="GhostPath" type="Spatial"]
 script = ExtResource( 1 )
@@ -13,15 +59,20 @@ script = ExtResource( 1 )
 [node name="Path" type="Path" parent="."]
 curve = null
 
-[node name="CSGPolygon" type="CSGPolygon" parent="Path"]
-material_override = SubResource( 1 )
+[node name="PathCSGPolygon" type="CSGPolygon" parent="Path"]
+material_override = SubResource( 2 )
 cast_shadow = 0
+calculate_tangents = false
 invert_faces = true
 polygon = PoolVector2Array( 0, 0, 0, 0.5, 0.5, 0.5, 0.5, 0 )
 mode = 2
 path_node = NodePath("..")
+path_interval_type = 0
 path_interval = 1.0
+path_simplify_angle = 0.0
 path_rotation = 1
 path_local = false
-path_continuous_u = false
+path_continuous_u = true
+path_u_distance = 0.0
 path_joined = false
+script = ExtResource( 3 )

--- a/recursio-client/Rendering/PathCSGPolygon.gd
+++ b/recursio-client/Rendering/PathCSGPolygon.gd
@@ -1,0 +1,9 @@
+extends CSGPolygon
+
+
+var color setget set_color
+
+
+# Adapter to make `ColorManager.color_object_by_property` integrate neatly
+func set_color(new_color: Color):
+	material_override.set_shader_param("color", new_color)


### PR DESCRIPTION
Closes #150.

- path points are inserted every 15 rather than every 30 frames
- paths begin with 100% opacity and go towards 0%
- in addition, a wave effect makes it easier to visually parse intersections and get even better info about timing
- unselected paths are always grey; the selected path is always a much more vibrant purple (`player_ghost_secondary_accent`)
    - we don't differentiate between timelines anymore since that info is in the icon anyways and it might make it harder to get used to what the path colors mean

https://user-images.githubusercontent.com/18697097/146847543-702db4a1-894a-4e48-8470-bc7132c22dfe.mp4


