### PR TITLE
Obstructed ghost death fix

### DIFF
--- a/Shared/Actions/HitData.gd
+++ b/Shared/Actions/HitData.gd
@@ -1,0 +1,55 @@
+extends Reference
+class_name HitData
+
+enum HitType {
+	MELEE,
+	HITSCAN,
+	WALL
+}
+
+var type
+var position: Vector3
+var rotation: float
+
+var victim_team_id: int
+var victim_round_index: int 
+var victim_timeline_index: int
+
+var perpetrator_team_id: int
+var perpetrator_round_index: int 
+var perpetrator_timeline_index: int
+
+
+# Converts this class into an array
+func to_array()-> Array:
+	var array := [
+		type, 
+		position, 
+		rotation, 
+		victim_team_id, 
+		victim_round_index, 
+		victim_timeline_index, 
+		perpetrator_team_id, 
+		perpetrator_round_index,
+		perpetrator_timeline_index
+		]
+	return array
+
+
+# Fills the object with the data from the given array
+func from_array(data: Array)-> HitData:
+	type = data[0]
+	position = data[1]
+	rotation = data[2]
+	victim_team_id = data[3]
+	victim_round_index = data[4]
+	victim_timeline_index = data[5]
+	perpetrator_team_id = data[6]
+	perpetrator_round_index = data[7]
+	perpetrator_timeline_index = data[8]
+	return self
+
+func to_string() -> String:
+	var format_string = "TYPE:%s\nPOSITION:%s\nROTATION:%s\nVICTIM TEAM ID:%s\nVICTIM ROUND INDEX:%s\nVICTIM TIMELINE INDEX:%s\nPERPETRATOR TEAM ID:%s\nPERPETRATOR ROUND INDEX:%s\nPERPETRATOR TIMELINE INDEX:%s\n"
+	var actual_string = format_string % to_array()
+	return actual_string

--- a/Shared/Actions/Melee/Melee.gd
+++ b/Shared/Actions/Melee/Melee.gd
@@ -21,7 +21,25 @@ func _hit_body(collider):
 	_hit_something = true
 	if character is CharacterBase:
 		assert(character.has_method("hit"))
-		character.hit(_owning_player)
+		character.hit(_create_hit_data(character, HitData.HitType.MELEE))
+
+func _create_hit_data(victim: CharacterBase, type) -> HitData:
+	var hit_data = HitData.new()
+	
+	hit_data.type = type
+	hit_data.position = global_transform.origin
+	hit_data.rotation = global_transform.basis.get_euler().y
+	
+	hit_data.victim_team_id = victim.team_id
+	hit_data.victim_round_index = victim.round_index
+	hit_data.victim_timeline_index = victim.timeline_index
+	
+	hit_data.perpetrator_team_id = _owning_player.team_id
+	hit_data.perpetrator_round_index = _owning_player.round_index
+	hit_data.perpetrator_timeline_index = _owning_player.timeline_index
+	
+	return hit_data
+
 
 func _physics_process(_delta):
 	if _hit_something:

--- a/Shared/Actions/Melee/Melee.gd
+++ b/Shared/Actions/Melee/Melee.gd
@@ -23,6 +23,7 @@ func _hit_body(collider):
 		assert(character.has_method("hit"))
 		character.hit(_create_hit_data(character, HitData.HitType.MELEE))
 
+# TODO: this function is duplicate among all damaging actions, a shared interface would be nice maybe
 func _create_hit_data(victim: CharacterBase, type) -> HitData:
 	var hit_data = HitData.new()
 	

--- a/Shared/Actions/Shots/HitscanShot.gd
+++ b/Shared/Actions/Shots/HitscanShot.gd
@@ -76,8 +76,24 @@ func handle_hit(collider):
 	
 	if character is CharacterBase:
 		assert(character.has_method("hit"))
-		character.hit(_owning_player)
+		character.hit(_create_hit_data(character, HitData.HitType.HITSCAN))
 
+func _create_hit_data(victim: CharacterBase, type) -> HitData:
+	var hit_data = HitData.new()
+	
+	hit_data.type = type
+	hit_data.position = global_transform.origin
+	hit_data.rotation = global_transform.basis.get_euler().y
+	
+	hit_data.victim_team_id = victim.team_id
+	hit_data.victim_round_index = victim.round_index
+	hit_data.victim_timeline_index = victim.timeline_index
+	
+	hit_data.perpetrator_team_id = _owning_player.team_id
+	hit_data.perpetrator_round_index = _owning_player.round_index
+	hit_data.perpetrator_timeline_index = _owning_player.timeline_index
+	
+	return hit_data
 
 func _update_collision():
 	var collider = get_collider()

--- a/Shared/Actions/Shots/HitscanShot.gd
+++ b/Shared/Actions/Shots/HitscanShot.gd
@@ -78,6 +78,7 @@ func handle_hit(collider):
 		assert(character.has_method("hit"))
 		character.hit(_create_hit_data(character, HitData.HitType.HITSCAN))
 
+# TODO: this function is duplicate among all damaging actions, a shared interface would be nice maybe
 func _create_hit_data(victim: CharacterBase, type) -> HitData:
 	var hit_data = HitData.new()
 	

--- a/Shared/Actions/Shots/Wall.gd
+++ b/Shared/Actions/Shots/Wall.gd
@@ -61,7 +61,7 @@ func handle_hit(collider):
 			and character.round_index < round_index:
 		character.hit(_create_hit_data(character, HitData.HitType.HITSCAN))
 
-
+# TODO: this function is duplicate among all damaging actions, a shared interface would be nice maybe
 func _create_hit_data(victim: CharacterBase, type) -> HitData:
 	var hit_data = HitData.new()
 	

--- a/Shared/Actions/Shots/Wall.gd
+++ b/Shared/Actions/Shots/Wall.gd
@@ -1,4 +1,5 @@
 extends StaticBody
+class_name Wall
 
 export var animation_time:= 3.0
 

--- a/Shared/Actions/Shots/Wall.gd
+++ b/Shared/Actions/Shots/Wall.gd
@@ -58,4 +58,22 @@ func handle_hit(collider):
 
 	if character is GhostBase and not character == placed_by_body \
 			and character.round_index < round_index:
-		character.hit(_owning_player)
+		character.hit(_create_hit_data(character, HitData.HitType.HITSCAN))
+
+
+func _create_hit_data(victim: CharacterBase, type) -> HitData:
+	var hit_data = HitData.new()
+	
+	hit_data.type = type
+	hit_data.position = global_transform.origin
+	hit_data.rotation = global_transform.basis.get_euler().y
+	
+	hit_data.victim_team_id = victim.team_id
+	hit_data.victim_round_index = victim.round_index
+	hit_data.victim_timeline_index = victim.timeline_index
+	
+	hit_data.perpetrator_team_id = _owning_player.team_id
+	hit_data.perpetrator_round_index = _owning_player.round_index
+	hit_data.perpetrator_timeline_index = _owning_player.timeline_index
+	
+	return hit_data

--- a/Shared/Characters/CharacterBase.gd
+++ b/Shared/Characters/CharacterBase.gd
@@ -1,9 +1,9 @@
 extends Node
 class_name CharacterBase
 
-signal hit(perpetrator)
+signal hit(hit_data)
 #warning-ignore:unused_signal
-signal client_hit(perpetrator)
+signal client_hit(hit_data)
 signal dying()
 signal spawning()
 signal respawned()
@@ -120,16 +120,16 @@ func set_timeline_index(new_timeline_index: int):
 		timeline_index = new_timeline_index
 		emit_signal("timeline_index_changed", new_timeline_index)
 
-func hit(perpetrator) -> void:
+func hit(hit_data: HitData) -> void:
 	set_dying(true)
-	emit_signal("hit", perpetrator)
+	emit_signal("hit", hit_data)
 
 
 # quiet_hit is used to tell a character it is hit, without it triggering the hit signal
 # this is necessary because lots of gameplay functionality listens to hit (eg. recording 
 # of the death in the ghostmanager class) we do nott want this during special gameplay 
 # moments (for now only when a death is triggered by a previous death recording from the ghostmanager)
-func quiet_hit(_perpetrator) -> void:
+func quiet_hit(_hit_data: HitData) -> void:
 	set_dying(true)
 
 

--- a/Shared/Characters/GhostBase.gd
+++ b/Shared/Characters/GhostBase.gd
@@ -54,14 +54,14 @@ func update(_delta):
 
 # Stops the ghost and triggers the base classes hit function
 # OVERRIDE #
-func hit(perpetrator) -> void:
+func hit(hit_data: HitData) -> void:
 	_is_playing = false
-	.hit(perpetrator)
+	.hit(hit_data)
 
 # OVERRIDE #
-func quiet_hit(perpetrator) -> void:
+func quiet_hit(hit_data: HitData) -> void:
 	_is_playing = false
-	.quiet_hit(perpetrator)
+	.quiet_hit(hit_data)
 	
 # Starts moving the ghost and enables collision
 func start_playing(start_time: int) -> void:

--- a/Shared/GhostManagerBase.gd
+++ b/Shared/GhostManagerBase.gd
@@ -2,9 +2,9 @@ extends Node
 class_name GhostManager
 
 #warning-ignore:unused_signal
-signal ghost_hit(victim_player_id, victim_timeline_index, perpetrator_player_id, perpetrator_timeline_index)
+signal ghost_hit(hit_data)
 #warning-ignore:unused_signal
-signal quiet_ghost_hit(victim_player_id, victim_timeline_index, perpetrator_player_id, perpetrator_timeline_index)
+signal quiet_ghost_hit(hit_data)
 #warning-ignore:unused_signal
 signal new_record_data_applied(player)
 
@@ -78,7 +78,7 @@ func _use_new_record_data():
 
 
 # ABSTRACT #
-func _on_ghost_hit(_perpetrator, _victim):
+func _on_ghost_hit(_hit_data: HitData):
 	assert(false) #this must be overwritten in child class
 
 

--- a/Shared/Recording/DeathData.gd
+++ b/Shared/Recording/DeathData.gd
@@ -1,4 +1,4 @@
-extends Object
+extends Reference
 class_name DeathData
 
 # in msecs passed since gamephase start

--- a/Shared/Recording/DeathData.gd
+++ b/Shared/Recording/DeathData.gd
@@ -1,23 +1,7 @@
 extends Object
 class_name DeathData
 
-enum HitType {
-	MELEE,
-	HITSCAN,
-	WALL
-}
-
-var hit_type
-var hit_position
-var hit_rotation
-
 # in msecs passed since gamephase start
-var time
+var time: int
 
-var victim_team_id: int
-var victim_round_index: int 
-var victim_timeline_index: int
-
-var perpetrator_team_id: int
-var perpetrator_round_index: int 
-var perpetrator_timeline_index: int
+var hit_data: HitData

--- a/Shared/Recording/DeathData.gd
+++ b/Shared/Recording/DeathData.gd
@@ -1,6 +1,15 @@
 extends Object
 class_name DeathData
 
+enum HitType {
+	MELEE,
+	HITSCAN,
+	WALL
+}
+
+var hit_type
+var hit_position
+var hit_rotation
 
 # in msecs passed since gamephase start
 var time

--- a/Shared/Recording/DeathData.gd
+++ b/Shared/Recording/DeathData.gd
@@ -1,5 +1,6 @@
 extends Object
-class_name GhostDeathData
+class_name DeathData
+
 
 # in msecs passed since gamephase start
 var time

--- a/recursio-client/Characters/Enemy.gd
+++ b/recursio-client/Characters/Enemy.gd
@@ -15,8 +15,8 @@ func enemy_init(action_manager: ActionManager) -> void:
 
 # OVERRIDE #
 # Only emit signal for client
-func hit(perpetrator):
-	emit_signal("client_hit", perpetrator)
+func hit(hit_data: HitData):
+	emit_signal("client_hit", hit_data)
 
-func server_hit(perpetrator):
-	.hit(perpetrator)
+func server_hit(hit_data: HitData):
+	.hit(hit_data)

--- a/recursio-client/Characters/Ghost.gd
+++ b/recursio-client/Characters/Ghost.gd
@@ -31,13 +31,13 @@ func start_playing(start_time: int) -> void:
 
 # OVERRIDE #
 # Only emit signal for client
-func hit(perpetrator):
-	emit_signal("client_hit", perpetrator)
+func hit(hit_data: HitData):
+	emit_signal("client_hit", hit_data)
 
 # Displays ghost as dead
 # calls hit of base function triggered by server
-func server_hit(perpetrator):
+func server_hit(hit_data: HitData):
 	assert(is_record_data_set())
-	.hit(perpetrator)
+	.hit(hit_data)
 	#_minimap_icon.set_texture(_minimap_icon_dead)
 

--- a/recursio-client/Characters/Player.gd
+++ b/recursio-client/Characters/Player.gd
@@ -350,13 +350,13 @@ func toggle_visibility_light(value: bool):
 
 # OVERRIDE #
 # Only emit signal for client
-func hit(perpetrator):
-	emit_signal("client_hit", perpetrator)
+func hit(hit_data: HitData):
+	emit_signal("client_hit", hit_data)
 
 
 # call hit of baseclass triggered by server
-func server_hit(perpetrator):
-	.hit(perpetrator)
+func server_hit(hit_data: HitData):
+	.hit(hit_data)
 
 # TODO: this should probably not be in player.gd, but I don't really know where else to put it
 func get_camera():

--- a/recursio-client/Global/Server.gd
+++ b/recursio-client/Global/Server.gd
@@ -293,7 +293,6 @@ remote func receive_game_result(winning_player_id):
 remote func receive_player_hit(hit_data_as_array: Array):
 	var hit_data = HitData.new().from_array(hit_data_as_array)
 	Logger.debug("Player hit received: " + str(hit_data.victim_team_id), "server")
-	print(hit_data.to_string())
 	emit_signal("player_hit", hit_data)
 
 

--- a/recursio-client/Global/Server.gd
+++ b/recursio-client/Global/Server.gd
@@ -34,9 +34,9 @@ signal capture_point_team_changed(capturing_player_team_id, capture_point)
 signal capture_point_status_changed(capturing_player_team_id, capture_point, capture_progress)
 signal capture_point_capture_lost(capturing_player_team_id, capture_point)
 signal game_result(winning_player_id)
-signal player_hit(hit_player_id, perpetrator_player_id, perpetrator_timeline_index)
-signal ghost_hit(hit_ghost_player_owner, hit_ghost_id, perpetrator_player_id, perpetrator_timeline_index)
-signal quiet_ghost_hit(hit_ghost_player_owner, hit_ghost_id, perpetrator_player_id, perpetrator_timeline_index)
+signal player_hit(hit_data)
+signal ghost_hit(hit_data)
+signal quiet_ghost_hit(hit_data)
 signal timeline_picked(picking_player_id, timeline_index)
 signal wall_spawn (position, rotation, wall_index)
 
@@ -290,18 +290,22 @@ remote func receive_game_result(winning_player_id):
 	emit_signal("game_result", winning_player_id)
 
 
-remote func receive_player_hit(hit_player_id, perpetrator_player_id, perpetrator_timeline_index):
-	Logger.debug("Player hit received: " + str(hit_player_id), "server")
-	emit_signal("player_hit", hit_player_id, perpetrator_player_id, perpetrator_timeline_index)
+remote func receive_player_hit(hit_data_as_array: Array):
+	var hit_data = HitData.new().from_array(hit_data_as_array)
+	Logger.debug("Player hit received: " + str(hit_data.victim_team_id), "server")
+	print(hit_data.to_string())
+	emit_signal("player_hit", hit_data)
 
 
-remote func receive_ghost_hit(victim_player_id, victim_timeline_index, perpetrator_player_id, perpetrator_timeline_index):
-	Logger.debug("Ghost hit received: " + str(victim_timeline_index) + " of player " + str(victim_player_id), "server")
-	emit_signal("ghost_hit", victim_player_id, victim_timeline_index, perpetrator_player_id, perpetrator_timeline_index)
+remote func receive_ghost_hit(hit_data_as_array: Array):
+	var hit_data = HitData.new().from_array(hit_data_as_array)
+	Logger.debug("Hit received of Ghost #" + str(hit_data.victim_timeline_index) + " of Player " + str(hit_data.victim_team_id), "server")
+	emit_signal("ghost_hit", hit_data)
 
-remote func receive_quiet_ghost_hit(victim_player_id, victim_timeline_index, perpetrator_player_id, perpetrator_timeline_index):
-	Logger.debug("Quiet ghost hit received: " + str(victim_timeline_index) + " of player " + str(victim_player_id), "server")
-	emit_signal("quiet_ghost_hit", victim_player_id, victim_timeline_index, perpetrator_player_id, perpetrator_timeline_index)
+remote func receive_quiet_ghost_hit(hit_data_as_array: Array):
+	var hit_data = HitData.new().from_array(hit_data_as_array)
+	Logger.debug("Quiet ghost hit received: " + str(hit_data.victim_timeline_index) + " of player " + str(hit_data.victim_team_id), "server")
+	emit_signal("quiet_ghost_hit", hit_data)
 
 remote func receive_player_action(action_player_id, action_type):
 	Logger.debug("Other player action received: " + str(action_type), "server")

--- a/recursio-client/Managers/CharacterManager.gd
+++ b/recursio-client/Managers/CharacterManager.gd
@@ -311,12 +311,11 @@ func _on_world_state_received(world_state: WorldState):
 				_enemy.server_acceleration = player_states[id].acceleration
 				_enemy.last_triggers |= player_states[id].buttons
 
-func _on_player_hit(hit_player_id, perpetrator_player_id, perpetrator_timeline_index) -> void:
-	var perpetrator = _ghost_manager._find_perpetrator(perpetrator_player_id, perpetrator_timeline_index)
-	if hit_player_id == _player_rpc_id:
-		_player.server_hit(perpetrator) 
+func _on_player_hit(hit_data: HitData) -> void:
+	if hit_data.victim_team_id == _player.team_id:
+		_player.server_hit(hit_data) 
 	else:
-		 _enemy.server_hit(perpetrator)
+		_enemy.server_hit(hit_data)
 
 func _on_capture_point_captured(capturing_player_team_id, _capture_point):
 	if capturing_player_team_id == _player.team_id:

--- a/recursio-client/Managers/ClientGhostManager.gd
+++ b/recursio-client/Managers/ClientGhostManager.gd
@@ -90,7 +90,7 @@ func _use_new_record_data():
 
 
 # OVERRIDE ABSTRACT #
-func _on_ghost_hit(_perpetrator, _victim):
+func _on_ghost_hit(_hit_data: HitData):
 	# local ghost hits should not trigger anything on the client
 	pass
 
@@ -104,28 +104,26 @@ func on_enemy_ghost_record_received(timeline_index,round_index,  record_data: Re
 	_update_ghost_record(_enemy_ghosts, timeline_index, record_data, round_index)
 
 
-func on_ghost_hit_from_server(victim_player_id, victim_timeline_index, perpetrator_player_id, perpetrator_timeline_index) -> void:
+func on_ghost_hit_from_server(hit_data: HitData) -> void:
 	var ghost 
-	if victim_player_id == _character_manager._player.player_id:
-		ghost = _player_ghosts[victim_timeline_index]
+	if hit_data.victim_team_id == _character_manager._player.team_id:
+		ghost = _player_ghosts[hit_data.victim_timeline_index]
 		ghost.toggle_visibility_light(false)
 	else:
-		ghost = _enemy_ghosts[victim_timeline_index]
-	var perpetrator = _find_perpetrator(perpetrator_player_id, perpetrator_timeline_index)
-	ghost.server_hit(perpetrator)
+		ghost = _enemy_ghosts[hit_data.victim_timeline_index]
+	ghost.server_hit(hit_data)
 
 
-func on_quiet_ghost_hit_from_server(victim_player_id, victim_timeline_index, perpetrator_player_id, perpetrator_timeline_index) -> void:
+func on_quiet_ghost_hit_from_server(hit_data: HitData) -> void:
 	#pretty much just the same code as with a normal hit (and nothing different should happen) but i used a different
 	#function just in case we would want to react to it differently at a future date
 	var ghost 
-	if victim_player_id == _character_manager._player.player_id:
-		ghost = _player_ghosts[victim_timeline_index]
+	if hit_data.victim_team_id == _character_manager._player.team_id:
+		ghost = _player_ghosts[hit_data.victim_timeline_index]
 		ghost.toggle_visibility_light(false)
 	else:
-		ghost = _enemy_ghosts[victim_timeline_index]
-	var perpetrator = _find_perpetrator(perpetrator_player_id, perpetrator_timeline_index)
-	ghost.quiet_hit(perpetrator)
+		ghost = _enemy_ghosts[hit_data.victim_timeline_index]
+	ghost.quiet_hit(hit_data)
 
 
 func refresh_path_select():
@@ -134,18 +132,18 @@ func refresh_path_select():
 	_player_ghosts[_character_manager._player.timeline_index].toggle_path_select(true)
 
 
-func _find_perpetrator(perpetrator_player_id, perpetrator_timeline_index):
+func _find_perpetrator(hit_data: HitData):
 	# First checking if it was one of the active players
 	var player = _character_manager.get_player()
 	var enemy = _character_manager.get_enemy()
-	var player_team = (player.player_id == perpetrator_player_id)
+	var player_team = (player.team_id == hit_data.perpetrator_team_id)
 	var active_perpetrator_player = player if player_team else enemy
-	if active_perpetrator_player.timeline_index == perpetrator_player_id:
+	if active_perpetrator_player.timeline_index == hit_data.perpetrator_timeline_index:
 		return active_perpetrator_player
 	
 	# Now looking through the ghosts:
 	var ghosts = _player_ghosts if player_team else _enemy_ghosts
-	return ghosts[perpetrator_timeline_index]
+	return ghosts[hit_data.perpetrator_timeline_index]
 
 
 func _toggle_visbility_lights(value: bool):

--- a/recursio-client/Managers/GameManager.gd
+++ b/recursio-client/Managers/GameManager.gd
@@ -112,30 +112,30 @@ func _on_game_result(winning_player_index) -> void:
 			_game_end_screen.set_title("You Lost!")
 
 
-func _on_player_hit(hit_player_id, perpetrator_player_id, perpetrator_timeline_index) -> void:
-	if hit_player_id == _player.player_id:
+func _on_player_hit(hit_data: HitData) -> void:
+	if hit_data.victim_team_id == _player.team_id:
 		_player_deaths[_player.team_id] += 1
 	else:
 		_player_deaths[_enemy.team_id] += 1
-	_check_for_perpetrator(perpetrator_player_id, perpetrator_timeline_index)
+	_check_for_perpetrator(hit_data)
 
 
-func _on_ghost_hit(victim_player_id, _victim_timeline_index, perpetrator_player_id, perpetrator_timeline_index) -> void:
-	if victim_player_id == _player.player_id:
+func _on_ghost_hit(hit_data: HitData) -> void:
+	if hit_data.victim_team_id == _player.team_id:
 		_ghost_deaths[_player.team_id] += 1
 	else:
 		_ghost_deaths[_enemy.team_id] += 1
-	_check_for_perpetrator(perpetrator_player_id, perpetrator_timeline_index)
+	_check_for_perpetrator(hit_data)
 
 
-func _check_for_perpetrator(perpetrator_player_id, perpetrator_timeline_index) -> void:
-	if perpetrator_player_id == _player.player_id:
-		if perpetrator_timeline_index == _player.timeline_index:
+func _check_for_perpetrator(hit_data: HitData) -> void:
+	if hit_data.perpetrator_team_id == _player.team_id:
+		if hit_data.perpetrator_timeline_index == _player.timeline_index:
 			_player_kills[_player.team_id] += 1
 		else:
 			_ghost_kills[_player.team_id] += 1
 	else:
-		if perpetrator_timeline_index == _enemy.timeline_index:
+		if hit_data.perpetrator_timeline_index == _enemy.timeline_index:
 			_player_kills[_enemy.team_id] += 1
 		else:
 			_ghost_kills[_enemy.team_id] += 1

--- a/recursio-client/Tutorial/TutorialScenario_1.gd
+++ b/recursio-client/Tutorial/TutorialScenario_1.gd
@@ -156,5 +156,5 @@ func _enemy_killed_condition_end() -> void:
 	_enemy.kb.visible = false
 
 
-func _on_enemy_hit(perpetrator):
-	_enemy.server_hit(perpetrator)
+func _on_enemy_hit(hit_data: HitData):
+	_enemy.server_hit(hit_data)

--- a/recursio-client/Tutorial/TutorialScenario_2.gd
+++ b/recursio-client/Tutorial/TutorialScenario_2.gd
@@ -197,29 +197,29 @@ func _completed_round_3() -> void:
 	_bottom_element.hide()
 
 
-func _on_player_hit(perpetrator):
-	_player.server_hit(perpetrator)
+func _on_player_hit(hit_data: HitData):
+	_player.server_hit(hit_data)
 
 
-func _on_enemy_hit(perpetrator):
-	_enemy.server_hit(perpetrator)
+func _on_enemy_hit(hit_data: HitData):
+	_enemy.server_hit(hit_data)
 
 
-func _on_ghost_hit(perpetrator, ghost):
+func _on_ghost_hit(hit_data: HitData, ghost):
 	if ghost is PlayerGhost:
 		ghost.toggle_visibility_light(false)
-	ghost.server_hit(perpetrator)
+	ghost.server_hit(hit_data)
 
 
-func _on_ghost_hit_soft_lock(perpetrator, ghost: PlayerGhost):	
+func _on_ghost_hit_soft_lock(hit_data: HitData, ghost: PlayerGhost):	
 	_soft_locked = true
 	
 	ghost.toggle_visibility_light(false)
-	ghost.server_hit(perpetrator)
+	ghost.server_hit(hit_data)
 	
 	add_post_process_exception(_bottom_element)
 	_bottom_element.show()
-	if perpetrator is Player:
+	if hit_data.perpetrator_team_id == _player.team_id:
 		_bottom_element.set_content("Oh no, you killed your previous timeline!\nTry using a melee attack next time.", TutorialUIBottomElement.Controls.None, true)
 	else:
 		_bottom_element.set_content("Oh no, you did not prevent the death of your previous timeline!", TutorialUIBottomElement.Controls.None, true)
@@ -243,7 +243,7 @@ func _on_ghost_hit_soft_lock(perpetrator, ghost: PlayerGhost):
 	_goal_element_1.show()
 	_goal_element_2.show()
 	_goal_element_2.set_content("Repeats", _ghost_manager._player_ghosts[0].get_body())
-	if perpetrator is Player:
+	if hit_data.perpetrator_team_id == _player.team_id:
 		_bottom_element.set_content("Melee!", TutorialUIBottomElement.Controls.Melee)
 		_goal_element_1.set_content("Kill", _ghost_manager._enemy_ghosts[0].get_body())
 	else:

--- a/recursio-client/project.godot
+++ b/recursio-client/project.godot
@@ -74,6 +74,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://Util/DeadZones.gd"
 }, {
+"base": "Object",
+"class": "DeathData",
+"language": "GDScript",
+"path": "res://Shared/Recording/DeathData.gd"
+}, {
 "base": "Label",
 "class": "DynamicLabel",
 "language": "GDScript",
@@ -139,11 +144,6 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://Shared/Characters/GhostBase.gd"
 }, {
-"base": "Object",
-"class": "GhostDeathData",
-"language": "GDScript",
-"path": "res://Shared/Recording/GhostDeathData.gd"
-}, {
 "base": "Node",
 "class": "GhostManager",
 "language": "GDScript",
@@ -153,6 +153,11 @@ _global_script_classes=[ {
 "class": "HUD",
 "language": "GDScript",
 "path": "res://UI/HUD.gd"
+}, {
+"base": "Reference",
+"class": "HitData",
+"language": "GDScript",
+"path": "res://Shared/Actions/HitData.gd"
 }, {
 "base": "Object",
 "class": "InputData",
@@ -328,6 +333,7 @@ _global_script_class_icons={
 "ClientGhostManager": "",
 "ColorSetting": "",
 "DeadZones": "",
+"DeathData": "",
 "DynamicLabel": "",
 "Enemy": "",
 "EnemyAI": "",
@@ -341,9 +347,9 @@ _global_script_class_icons={
 "GameplayMenu": "",
 "Ghost": "",
 "GhostBase": "",
-"GhostDeathData": "",
 "GhostManager": "",
 "HUD": "",
+"HitData": "",
 "InputData": "",
 "InputFrame": "",
 "LerpedFollow": "",

--- a/recursio-server/GameRoom/CharacterManager.gd
+++ b/recursio-server/GameRoom/CharacterManager.gd
@@ -2,7 +2,7 @@ extends Node
 class_name CharacterManager
 
 signal world_state_updated(world_state)
-signal player_killed(victim, perpetrator)
+signal player_killed(hit_data)
 
 var _player_scene = preload("res://Shared/Characters/PlayerBase.tscn")
 
@@ -78,7 +78,7 @@ func spawn_player(player_id, team_id, player_user_name) -> void:
 	player.team_id = team_id
 	player.spawn_point = spawn_point
 	add_child(player)
-	var _error = player.connect("hit", self, "_on_player_hit", [player_id])
+	var _error = player.connect("hit", self, "_on_player_hit")
 	_error =player.connect("wall_spawn", self, "_on_wall_spawn", [player_id])
 
 	# Triggering spawns of enemies on all clients
@@ -120,12 +120,11 @@ func _propagate_current_timelines(picking_player_id, propagate_to_picking_player
 			Server.send_timeline_pick(client_id, player_id, player_dic[player_id].timeline_index)
 
 
-func _on_player_hit(perpetrator, victim_player_id):
+func _on_player_hit(hit_data: HitData):
 	Logger.info("Player hit!", "attacking")
-	var victim = player_dic[victim_player_id]
-	emit_signal("player_killed", victim, perpetrator)
+	emit_signal("player_killed", hit_data)
 	for player_id in player_dic:
-		Server.send_player_hit(player_id, victim_player_id, perpetrator.player_id, perpetrator.timeline_index)
+		Server.send_player_hit(player_id, hit_data)
 
 func _on_wall_spawn(position, rotation, wall_index, player_id):
 	Server.send_wall_spawn(position, rotation, wall_index, player_id)

--- a/recursio-server/GameRoom/GameRoomWorld.gd
+++ b/recursio-server/GameRoom/GameRoomWorld.gd
@@ -36,13 +36,13 @@ func _ready():
 	_world_state_manager.world_processing_offset = world_processing_offset
 	_character_manager.world_processing_offset = world_processing_offset
 
-func _on_ghost_hit(victim_player_id, victim_timeline_index, perpetrator_player_id, perpetrator_timeline_index):
+func _on_ghost_hit(hit_data: HitData):
 	for player_id in _character_manager.player_dic:
-		_server.send_ghost_hit(player_id, victim_player_id, victim_timeline_index, perpetrator_player_id, perpetrator_timeline_index)
+		_server.send_ghost_hit(player_id, hit_data)
 
-func _on_quiet_ghost_hit(owning_player_id, timeline_index, perpetrator_player_id, perpetrator_timeline_index):
+func _on_quiet_ghost_hit(hit_data):
 	for player_id in _character_manager.player_dic:
-		_server.send_quiet_ghost_hit(player_id, owning_player_id, timeline_index, perpetrator_player_id, perpetrator_timeline_index)
+		_server.send_quiet_ghost_hit(player_id, hit_data)
 
 
 func _on_new_record_data_applied(player):

--- a/recursio-server/GameRoom/ServerGhostManager.gd
+++ b/recursio-server/GameRoom/ServerGhostManager.gd
@@ -102,12 +102,12 @@ func _look_for_previous_death():
 			break
 
 
-func _apply_previous_death(ghost_death_data):
-	var victim_active = _is_ghost_active(ghost_death_data.victim_team_id,ghost_death_data.victim_round_index,ghost_death_data.victim_timeline_index)
-	var perpetrator_active = _is_ghost_active(ghost_death_data.perpetrator_team_id,ghost_death_data.perpetrator_round_index,ghost_death_data.perpetrator_timeline_index)
+func _apply_previous_death(death_data):
+	var victim_active = _is_ghost_active(death_data.victim_team_id,death_data.victim_round_index,death_data.victim_timeline_index)
+	var perpetrator_active = _is_ghost_active(death_data.perpetrator_team_id,death_data.perpetrator_round_index,death_data.perpetrator_timeline_index)
 	if victim_active and perpetrator_active:
-		var victim = _seperated_ghosts[ghost_death_data.victim_team_id][ghost_death_data.victim_timeline_index]
-		var perpetrator = _seperated_ghosts[ghost_death_data.perpetrator_team_id][ghost_death_data.perpetrator_timeline_index]
+		var victim = _seperated_ghosts[death_data.victim_team_id][death_data.victim_timeline_index]
+		var perpetrator = _seperated_ghosts[death_data.perpetrator_team_id][death_data.perpetrator_timeline_index]
 		emit_signal("quiet_ghost_hit", victim.player_id, victim.timeline_index, perpetrator.player_id, perpetrator.timeline_index)
 		victim.quiet_hit(perpetrator)
 
@@ -123,7 +123,7 @@ func _clear_old_ghost_death_data(perpetrator_team_id, perpetrator_timeline_index
 
 
 func _create_new_ghost_death_data(victim, perpetrator):
-	var ghost_data = GhostDeathData.new()
+	var ghost_data = DeathData.new()
 	
 	ghost_data.time = _server.get_server_time()-_game_phase_start_time
 

--- a/recursio-server/GameRoom/ServerGhostManager.gd
+++ b/recursio-server/GameRoom/ServerGhostManager.gd
@@ -72,7 +72,6 @@ func _use_new_record_data():
 # OVERRIDE ABSTRACT #
 func _on_ghost_hit(hit_data: HitData):
 	_new_previous_ghost_death.append(_create_new_ghost_death_data(hit_data))
-	# TODONOW: follow this thread
 	emit_signal("ghost_hit", hit_data)
 
 

--- a/recursio-server/Globals/Server.gd
+++ b/recursio-server/Globals/Server.gd
@@ -147,19 +147,19 @@ func send_game_result(player_id, winning_player_id):
 	rpc_id(player_id, "receive_game_result", winning_player_id)
 
 
-func send_player_hit(player_id, victim_player_id, perpetrator_player_id, perpetrator_timeline_index):
+func send_player_hit(player_id, hit_data: HitData):
 	Logger.info("Sending player hit to client", "connection")
-	rpc_id(player_id, "receive_player_hit", victim_player_id, perpetrator_player_id, perpetrator_timeline_index)
+	rpc_id(player_id, "receive_player_hit", hit_data.to_array())
 
 
-func send_ghost_hit(player_id, victim_player_id, victim_timeline_index, perpetrator_player_id, perpetrator_timeline_index):
+func send_ghost_hit(player_id, hit_data):
 	Logger.info("Sending ghost hit to client", "connection")
-	rpc_id(player_id, "receive_ghost_hit", victim_player_id, victim_timeline_index, perpetrator_player_id, perpetrator_timeline_index)
+	rpc_id(player_id, "receive_ghost_hit", hit_data.to_array())
 
 
-func send_quiet_ghost_hit(player_id, victim_player_id, victim_timeline_index, perpetrator_player_id, perpetrator_timeline_index):
+func send_quiet_ghost_hit(player_id, hit_data):
 	Logger.info("Sending quiet ghost hit to client", "connection")
-	rpc_id(player_id, "receive_quiet_ghost_hit", victim_player_id, victim_timeline_index, perpetrator_player_id, perpetrator_timeline_index)
+	rpc_id(player_id, "receive_quiet_ghost_hit", hit_data.to_array())
 
 
 func send_timeline_pick(player_id, picking_player_id, timeline_index):

--- a/recursio-server/project.godot
+++ b/recursio-server/project.godot
@@ -34,7 +34,7 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://GameRoom/CharacterManager.gd"
 }, {
-"base": "Object",
+"base": "Reference",
 "class": "DeathData",
 "language": "GDScript",
 "path": "res://Shared/Recording/DeathData.gd"
@@ -144,6 +144,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://Shared/Input/StaticInput.gd"
 }, {
+"base": "StaticBody",
+"class": "Wall",
+"language": "GDScript",
+"path": "res://Shared/Actions/Shots/Wall.gd"
+}, {
 "base": "Object",
 "class": "WorldState",
 "language": "GDScript",
@@ -182,6 +187,7 @@ _global_script_class_icons={
 "ServerCapturePoint": "",
 "ServerGhostManager": "",
 "StaticInput": "",
+"Wall": "",
 "WorldState": "",
 "WorldStateManager": ""
 }

--- a/recursio-server/project.godot
+++ b/recursio-server/project.godot
@@ -34,6 +34,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://GameRoom/CharacterManager.gd"
 }, {
+"base": "Object",
+"class": "DeathData",
+"language": "GDScript",
+"path": "res://Shared/Recording/DeathData.gd"
+}, {
 "base": "Node",
 "class": "GameManager",
 "language": "GDScript",
@@ -58,11 +63,6 @@ _global_script_classes=[ {
 "class": "GhostBase",
 "language": "GDScript",
 "path": "res://Shared/Characters/GhostBase.gd"
-}, {
-"base": "Object",
-"class": "GhostDeathData",
-"language": "GDScript",
-"path": "res://Shared/Recording/GhostDeathData.gd"
 }, {
 "base": "Node",
 "class": "GhostManager",
@@ -155,12 +155,12 @@ _global_script_class_icons={
 "BaseCapturePoint": "",
 "CharacterBase": "",
 "CharacterManager": "",
+"DeathData": "",
 "GameManager": "",
 "GameRoom": "",
 "GameRoomManager": "",
 "GameRoomWorld": "",
 "GhostBase": "",
-"GhostDeathData": "",
 "GhostManager": "",
 "InputData": "",
 "InputFrame": "",

--- a/recursio-server/project.godot
+++ b/recursio-server/project.godot
@@ -69,6 +69,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://Shared/GhostManagerBase.gd"
 }, {
+"base": "Reference",
+"class": "HitData",
+"language": "GDScript",
+"path": "res://Shared/Actions/HitData.gd"
+}, {
 "base": "Object",
 "class": "InputData",
 "language": "GDScript",
@@ -162,6 +167,7 @@ _global_script_class_icons={
 "GameRoomWorld": "",
 "GhostBase": "",
 "GhostManager": "",
+"HitData": "",
 "InputData": "",
 "InputFrame": "",
 "Level": "",


### PR DESCRIPTION
Fixes previous ghosts deaths still being applied even if the hitscan shot would be blocked by either a player or a wall. 
Hits now propagate a HitData object containing all relevant information one would need to know about the hit. This is used to raycast for previous hitscan shot deaths to see if any obstruction is in the way.

Closes #200 