### PR TITLE
Add confirmations to local wall

### DIFF
--- a/Shared/Actions/Shots/Wall.gd
+++ b/Shared/Actions/Shots/Wall.gd
@@ -9,6 +9,13 @@ var placed_by_body
 var round_index
 var _owning_player
 
+onready var _server: Server = get_node("/root/Server")
+
+var needs_server_confirmation = false
+# TODO: this value is very random, figure out a good one
+var _timer_confirmation_deadline = 2
+var confirmed = false
+
 func _init() -> void:
 	Logger.info("_init action", "Wall")
 
@@ -19,12 +26,19 @@ func ease_out_elastic(x: float, wobble: float) -> float:
 
 func _process(delta):
 	_time_since_spawn += delta
-	var ratio = min(1, _time_since_spawn/animation_time)
-	var remapped_ratio = ease_out_elastic(ratio,15.0)
-	_mesh_pivot.scale = Vector3(1, remapped_ratio, 1)
+	if _time_since_spawn <= animation_time:
+		var ratio = min(1, _time_since_spawn/animation_time)
+		var remapped_ratio = ease_out_elastic(ratio,15.0)
+		_mesh_pivot.scale = Vector3(1, remapped_ratio, 1)
+	else:
+		_mesh_pivot.scale = Vector3(1, 1, 1)
 	
-	if _time_since_spawn >= animation_time:
-		set_physics_process(false)
+	
+	if needs_server_confirmation and _server.is_connection_active:
+		if not confirmed:
+			if _time_since_spawn > _timer_confirmation_deadline:
+				_owning_player.wall_despawned(self)
+				queue_free()
 
 func _ready():
 	var _error = $KillGhostArea.connect("body_entered", self, "handle_hit") 

--- a/Shared/Characters/CharacterBase.gd
+++ b/Shared/Characters/CharacterBase.gd
@@ -212,6 +212,9 @@ func wall_spawned(_wall):
 	pass
 
 
+func wall_despawned(_wall):
+	pass
+
 func visual_delayed_spawn(delay: float):
 	_spawn_imminent = true
 	_spawn_deadline = delay

--- a/recursio-client/Characters/Player.gd
+++ b/recursio-client/Characters/Player.gd
@@ -165,8 +165,16 @@ func _get_action(trigger, timeline_index):
 
 # OVERRIDE #
 func wall_spawned(wall):
+	wall.needs_server_confirmation = true
 	_walls.append(wall)
 
+# OVERRIDE #
+func wall_despawned(wall):
+	_walls.erase(wall)
+	var wall_action_index = Constants.get_value("ghosts", "wall_placing_timeline_index")
+	var wall_action = _get_action(ActionManager.Trigger.FIRE_START, wall_action_index)
+	wall_action.ammunition += 1
+	wall_action.emit_signal("ammunition_changed", wall_action.ammunition)
 
 func _on_wall_spawn_received(position, rotation, wall_index):
 	if _walls.size()>wall_index:
@@ -175,6 +183,7 @@ func _on_wall_spawn_received(position, rotation, wall_index):
 			_walls[wall_index].global_transform.origin = position
 			#TODO: is rotation global here, could be dangerous if it isn't
 			_walls[wall_index].rotation.y = rotation
+			_walls[wall_index].confirmed = true
 	else:
 		var wall_action_index = Constants.get_value("ghosts", "wall_placing_timeline_index")
 		_action_manager.set_active(_get_action(ActionManager.Trigger.FIRE_START, wall_action_index) as Action, self, kb, get_parent())

--- a/recursio-server/project.godot
+++ b/recursio-server/project.godot
@@ -139,6 +139,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://Shared/Input/StaticInput.gd"
 }, {
+"base": "StaticBody",
+"class": "Wall",
+"language": "GDScript",
+"path": "res://Shared/Actions/Shots/Wall.gd"
+}, {
 "base": "Object",
 "class": "WorldState",
 "language": "GDScript",
@@ -176,6 +181,7 @@ _global_script_class_icons={
 "ServerCapturePoint": "",
 "ServerGhostManager": "",
 "StaticInput": "",
+"Wall": "",
 "WorldState": "",
 "WorldStateManager": ""
 }


### PR DESCRIPTION
Sometimes locally placed walls did not get to server, resulting in an disparate state between client and server. (This mainly happened when the player places a wall a split second before dying, which most likely meant he was already dead on the server so the locally place walled did not happen server side.) This fixes this by having local walls wait for a server confirmation. If they do not get the confirmation in time they despawn and give the player back their ammunition.