### PR TITLE
Properly reset capture point visuals

### DIFF
--- a/recursio-client/Level/ClientCapturePoint.gd
+++ b/recursio-client/Level/ClientCapturePoint.gd
@@ -55,6 +55,7 @@ func get_progress_team() -> int:
 # OVERRIDE #
 func reset() -> void:
 	.reset()
+	_progress.value = 0
 	_update_media()
 
 

--- a/recursio-client/Managers/CharacterManager.gd
+++ b/recursio-client/Managers/CharacterManager.gd
@@ -75,12 +75,12 @@ func _ready():
 	set_physics_process(false)
 
 func _physics_process(delta):
+	if _round_manager.get_current_phase() != RoundManager.Phases.GAME:
+		return
+	
 	# Update CapturePoints in player HUD
 	_player.update_capture_point_hud(_game_manager.get_capture_points())
 	
-	if _round_manager.get_current_phase() != RoundManager.Phases.GAME:
-		return
-
 	if enemy_is_server_driven and _enemy:
 		_update_enemy(delta)
 
@@ -318,11 +318,15 @@ func _on_player_hit(hit_data: HitData) -> void:
 		_enemy.server_hit(hit_data)
 
 func _on_capture_point_captured(capturing_player_team_id, _capture_point):
+	if _round_manager.get_current_phase() != RoundManager.Phases.GAME:
+		return
 	if capturing_player_team_id == _player.team_id:
 		_player.move_camera_to_overview()
 		_player.set_overview_light_enabled(true)
 
 func _on_capture_point_capture_lost(capturing_player_team_id, _capture_point):
+	if _round_manager.get_current_phase() != RoundManager.Phases.GAME:
+		return
 	if capturing_player_team_id == _player.team_id:
 		if _round_manager.get_current_phase() == RoundManager.Phases.GAME:
 			_player.follow_camera()

--- a/recursio-client/Managers/GameManager.gd
+++ b/recursio-client/Managers/GameManager.gd
@@ -142,17 +142,21 @@ func _check_for_perpetrator(hit_data: HitData) -> void:
 
 
 func _on_capture_point_captured(capturing_player_team_id: int, capture_point) -> void:
-	_level.get_capture_points()[capture_point].apply_server_capture_gained(capturing_player_team_id)
+	if _round_manager.get_current_phase() == RoundManager.Phases.GAME:
+		_level.get_capture_points()[capture_point].apply_server_capture_gained(capturing_player_team_id)
 
 
 func _on_capture_point_team_changed(capturing_player_team_id: int, capture_point) -> void:
-	_level.get_capture_points()[capture_point].apply_server_capturer_switched(capturing_player_team_id)
+	if _round_manager.get_current_phase() == RoundManager.Phases.GAME:
+		_level.get_capture_points()[capture_point].apply_server_capturer_switched(capturing_player_team_id)
 
 
 func _on_capture_point_status_changed(capturing_player_team_id: int, capture_point: int, capture_progress: float) -> void:
-	_level.get_capture_points()[capture_point].apply_server_capture_progress_changed(capturing_player_team_id, capture_progress)
+	if _round_manager.get_current_phase() == RoundManager.Phases.GAME:
+		_level.get_capture_points()[capture_point].apply_server_capture_progress_changed(capturing_player_team_id, capture_progress)
 
 
 func _on_capture_point_capture_lost(_capturing_player_team_id: int, capture_point: int) -> void:
-	_level.get_capture_points()[capture_point].apply_server_capture_lost()
+	if _round_manager.get_current_phase() == RoundManager.Phases.GAME:
+		_level.get_capture_points()[capture_point].apply_server_capture_lost()
 

--- a/recursio-client/UI/HUD.gd
+++ b/recursio-client/UI/HUD.gd
@@ -137,7 +137,8 @@ func prep_phase_start(round_index) -> void:
 	_controller_dash.show()
 	_dash.show()
 	_dash_bg.show()
-
+	for point in _capture_points:
+		point.reset()
 	# TODO: this should be set explicit from outside in dash actions
 	update_special_movement_ammo(2)
 


### PR DESCRIPTION
Added some missing `reset()` calls and stopped late server messages being applied outside the proper phase.

Closes #223.