### PR TITLE
Fix endless camera shake

### DIFF
--- a/recursio-client/Characters/Player.gd
+++ b/recursio-client/Characters/Player.gd
@@ -244,6 +244,10 @@ func follow_camera():
 	_lerped_follow.target = _view_target
 
 
+func stop_shake() -> void:
+	_lerped_follow.hard_stop_shake()
+
+
 func setup_capture_point_hud(number_of_capture_points) -> void:
 	for i in number_of_capture_points:
 		_hud.add_capture_point()

--- a/recursio-client/Managers/CharacterManager.gd
+++ b/recursio-client/Managers/CharacterManager.gd
@@ -165,6 +165,7 @@ func _on_preparation_phase_started() -> void:
 	_player.move_to_spawn_point()
 	_player.toggle_animation(false)
 	_enemy.toggle_animation(false)
+	_player.stop_shake()
 
 	_toggle_visbility_lights(false)
 	_action_manager.clear_action_instances()

--- a/recursio-client/Util/LerpedFollow.gd
+++ b/recursio-client/Util/LerpedFollow.gd
@@ -76,6 +76,16 @@ func stop_shake():
 		var goal_vector = Vector3.ZERO
 		_start_shake_tween(start_vector, goal_vector)
 
+# stops all shakes
+func hard_stop_shake():
+	_current_shake_count = 0
+	_shake_speed = 1
+	_tween.disconnect("tween_all_completed", self, "_on_shake_complete")
+	_tween.remove_all()
+	var start_vector = Vector3(_shake_vector.x, 0, _shake_vector.z)
+	var goal_vector = Vector3.ZERO
+	_start_shake_tween(start_vector, goal_vector)
+
 
 func _physics_process(_delta):
 	if _following:


### PR DESCRIPTION
This should now hard stop all camera shakes happening during the start of the prep phase.

Closes #224.