### PR TITLE
Add additional, different ground for visibility shader (fixes enemies always visible bug)

### DIFF
--- a/Shared/Level/LevelH.tscn
+++ b/Shared/Level/LevelH.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=24 format=2]
+[gd_scene load_steps=25 format=2]
 
 [ext_resource path="res://Shared/Level/Level.gd" type="Script" id=1]
 [ext_resource path="res://Shared/Level/LevelWalls.gd" type="Script" id=2]
@@ -57,6 +57,9 @@ albedo_color = Color( 0.27451, 0.541176, 0.494118, 1 )
 [sub_resource type="PlaneMesh" id=16]
 size = Vector2( 100, 100 )
 
+[sub_resource type="SpatialMaterial" id=24]
+albedo_color = Color( 0.266667, 0.266667, 0.266667, 1 )
+
 [node name="LevelH" type="Spatial"]
 script = ExtResource( 1 )
 
@@ -65,7 +68,6 @@ transform = Transform( 2, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )
 layers = 33
 material_override = SubResource( 17 )
 mesh = SubResource( 1 )
-material/0 = null
 script = ExtResource( 2 )
 
 [node name="StaticBody" type="StaticBody" parent="MidWall"]
@@ -78,7 +80,6 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 0.8, -6.5, 0, -1 )
 layers = 33
 material_override = SubResource( 18 )
 mesh = SubResource( 3 )
-material/0 = null
 script = ExtResource( 2 )
 
 [node name="StaticBody" type="StaticBody" parent="MidWall2"]
@@ -91,7 +92,6 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 0.8, 6.5, 0, 1 )
 layers = 33
 material_override = SubResource( 19 )
 mesh = SubResource( 3 )
-material/0 = null
 script = ExtResource( 2 )
 
 [node name="StaticBody" type="StaticBody" parent="MidWall3"]
@@ -134,7 +134,6 @@ transform = Transform( 1.5, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -20 )
 layers = 33
 material_override = SubResource( 20 )
 mesh = SubResource( 9 )
-material/0 = null
 script = ExtResource( 2 )
 
 [node name="StaticBody" type="StaticBody" parent="Wall1"]
@@ -147,7 +146,6 @@ transform = Transform( 1.5, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 20 )
 layers = 33
 material_override = SubResource( 21 )
 mesh = SubResource( 9 )
-material/0 = null
 script = ExtResource( 2 )
 
 [node name="StaticBody" type="StaticBody" parent="Wall2"]
@@ -160,7 +158,6 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1.3, 30, 0, 0 )
 layers = 33
 material_override = SubResource( 22 )
 mesh = SubResource( 12 )
-material/0 = null
 script = ExtResource( 2 )
 
 [node name="StaticBody" type="StaticBody" parent="Wall3"]
@@ -173,7 +170,6 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1.3, -30, 0, 0 )
 layers = 33
 material_override = SubResource( 23 )
 mesh = SubResource( 12 )
-material/0 = null
 script = ExtResource( 2 )
 
 [node name="StaticBody" type="StaticBody" parent="Wall4"]
@@ -183,10 +179,16 @@ shape = SubResource( 14 )
 
 [node name="Ground" type="MeshInstance" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.3, 0 )
-layers = 35
+layers = 33
 material_override = SubResource( 15 )
 mesh = SubResource( 16 )
-material/0 = null
+script = ExtResource( 3 )
+
+[node name="VisibilityLightGround" type="MeshInstance" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.3, 0 )
+layers = 2
+material_override = SubResource( 24 )
+mesh = SubResource( 16 )
 script = ExtResource( 3 )
 
 [node name="DirectionalLight" type="DirectionalLight" parent="."]


### PR DESCRIPTION
The ground color could previously affect the visibility cone shading: making it bright would make enemies always visible, since even little lighting would make it bright enough to be considered lit. This commit makes it more robust by adding a second ground just for the visibility shading, which is set to a dark grey color unaffected by user settings (which are now purely visual as intended).