### PR TITLE
Fix esc not doing anything

### DIFF
--- a/recursio-client/UI/Menus/GameplayMenu.gd
+++ b/recursio-client/UI/Menus/GameplayMenu.gd
@@ -25,8 +25,6 @@ func _process(_delta: float) -> void:
 	if Input.is_action_just_pressed("ui_cancel"):
 		if _settings.visible:
 			_settings.hide()
-		else:
-			_on_resume_pressed()
 
 
 func _on_visibility_changed() -> void:


### PR DESCRIPTION
As esc has two functions (opening the gameplay menu and going back), the gameplay menu was closed in the same frame it was opened.

Closes #252 