### PR TITLE
Add mouse cursor restriction during play

### DIFF
--- a/recursio-client/Characters/PlayerInput.gd
+++ b/recursio-client/Characters/PlayerInput.gd
@@ -29,6 +29,7 @@ func _ready():
 	_error = _player.connect("timeline_index_changed", self, "_swap_weapon_type")
 	
 	Input.set_mouse_mode(Input.MOUSE_MODE_CONFINED)
+	_error = UserSettings.connect("fullscreen_toggled", self, "_on_fullscreen_toggled")
 
 
 func _exit_tree():
@@ -128,3 +129,9 @@ func _get_buttons_pressed() -> int:
 				buttons |= _trigger_dic[trigger]
 
 	return buttons
+
+
+# This fixes the mouse confinement issue by toggling it off and on again
+func _on_fullscreen_toggled(_is_fullscreen):
+	Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+	Input.set_mouse_mode(Input.MOUSE_MODE_CONFINED)

--- a/recursio-client/Characters/PlayerInput.gd
+++ b/recursio-client/Characters/PlayerInput.gd
@@ -27,7 +27,13 @@ var _player_initialized: bool = false
 func _ready():
 	var _error = _player.connect("initialized", self, "_on_player_initialized")
 	_error = _player.connect("timeline_index_changed", self, "_swap_weapon_type")
+	
+	Input.set_mouse_mode(Input.MOUSE_MODE_CONFINED)
 
+
+func _exit_tree():
+	# Reverts mouse cursor to be visible but not confined
+	Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
 
 func _physics_process(_delta):
 	if not _player_initialized:

--- a/recursio-client/Global/UserSettings.gd
+++ b/recursio-client/Global/UserSettings.gd
@@ -1,5 +1,6 @@
 extends Node
 
+signal fullscreen_toggled(is_fullscreen)
 signal setting_changed(setting_header, setting_name)
 
 export var always_apply_defaults_at_startup := false
@@ -28,6 +29,7 @@ func _input(_event: InputEvent) -> void:
 	if Input.is_action_just_pressed("toggle_fullscreen"):
 		OS.set_window_fullscreen(!OS.window_fullscreen)
 		set_setting("video", "fullscreen", OS.window_fullscreen)
+		emit_signal("fullscreen_toggled", OS.window_fullscreen)
 
 
 func get_setting(setting_header, setting_name, default = null):

--- a/recursio-client/UI/Menus/FullScreenCheckButton.gd
+++ b/recursio-client/UI/Menus/FullScreenCheckButton.gd
@@ -11,6 +11,7 @@ func _ready():
 func _on_toggled(is_enabled):
 	OS.window_fullscreen = is_enabled
 	UserSettings.set_setting("video", "fullscreen", is_enabled)
+	UserSettings.emit_signal("fullscreen_toggled", is_enabled)
 
 
 func _on_fullscreen_changed(setting_header, setting_name, value):


### PR DESCRIPTION
Confines the mouse cursor when playing a game or the tutorial and frees it when going back to the start menu

Closes #248 