### PR TITLE
Use crosshair only during gameplay

### DIFF
--- a/recursio-client/Characters/PlayerInput.gd
+++ b/recursio-client/Characters/PlayerInput.gd
@@ -30,11 +30,14 @@ func _ready():
 	
 	Input.set_mouse_mode(Input.MOUSE_MODE_CONFINED)
 	_error = UserSettings.connect("fullscreen_toggled", self, "_on_fullscreen_toggled")
-
+	_on_controller_changed("")
+	_error = InputManager.connect("controller_changed",self,"_on_controller_changed")
 
 func _exit_tree():
 	# Reverts mouse cursor to be visible but not confined
 	Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+	Input.set_custom_mouse_cursor(null, Input.CURSOR_ARROW, InputManager.cursor_size)
+
 
 func _physics_process(_delta):
 	if not _player_initialized:
@@ -135,3 +138,6 @@ func _get_buttons_pressed() -> int:
 func _on_fullscreen_toggled(_is_fullscreen):
 	Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
 	Input.set_mouse_mode(Input.MOUSE_MODE_CONFINED)
+
+func _on_controller_changed(_controller):
+	Input.set_custom_mouse_cursor(InputManager.custom_cursor, Input.CURSOR_ARROW, InputManager.cursor_size)

--- a/recursio-client/Global/InputManager.gd
+++ b/recursio-client/Global/InputManager.gd
@@ -7,12 +7,14 @@ signal controller_changed(controller)
 var _current_controller := ""
 
 var _crosshair_cursor := preload("res://Resources/Icons/cursor_crosshair.png")
+var cursor_size
+var custom_cursor = null
 
 
 func _ready() -> void:
 	if not Input.is_connected("joy_connection_changed", self, "_on_joy_connection_changed"):
 		var _error = Input.connect("joy_connection_changed", self, "_on_joy_connection_changed")
-
+	cursor_size = _crosshair_cursor.get_size()/2
 	_update_controller_buttons()
 
 
@@ -73,8 +75,9 @@ func _update_controller_buttons() -> void:
 	# no controller: "keyboard"
 	if controller.size() < 1:
 		_current_controller = "keyboard"
-		Input.set_custom_mouse_cursor(_crosshair_cursor, Input.CURSOR_ARROW, _crosshair_cursor.get_size()/2)
+		custom_cursor = _crosshair_cursor
 	else:
+		custom_cursor = null
 		# take the first connected controller
 		var name = Input.get_joy_name(controller[0])
 		# Xbox Series Controller or XInput Gamepad for older: "xbox"

--- a/recursio-client/UI/Menus/GameplayMenu.gd
+++ b/recursio-client/UI/Menus/GameplayMenu.gd
@@ -19,6 +19,7 @@ func _ready():
 	_err = _btn_exit.connect("pressed", self, "_on_exit_pressed")
 	_err = self.connect("visibility_changed", self, "_on_visibility_changed")
 	_err = _settings.connect("visibility_changed", self, "_on_settings_visibility_changed")
+	_err = InputManager.connect("controller_changed",self,"_on_controller_changed")
 
 
 func _process(_delta: float) -> void:
@@ -30,8 +31,10 @@ func _process(_delta: float) -> void:
 func _on_visibility_changed() -> void:
 	if visible:
 		_btn_resume.grab_focus()
+		Input.set_custom_mouse_cursor(null, Input.CURSOR_ARROW, InputManager.cursor_size)
 	else:
 		_settings.hide()
+		Input.set_custom_mouse_cursor(InputManager.custom_cursor, Input.CURSOR_ARROW, InputManager.cursor_size)
 
 
 func _on_settings_visibility_changed() -> void:
@@ -55,3 +58,8 @@ func _on_leave_pressed() -> void:
 
 func _on_exit_pressed() -> void:
 	get_tree().quit()
+
+func _on_controller_changed(_controller):
+	if visible:
+		# override changing to cross hair when controller is plugged out while menu is open
+		Input.call_deferred("set_custom_mouse_cursor", null, Input.CURSOR_ARROW, InputManager.cursor_size)


### PR DESCRIPTION
Only uses the crosshair for the cursor during gameplay when no controller is connected (and the gameplay menu isn't opened)